### PR TITLE
feat: Enhance githubusers tool

### DIFF
--- a/githubusers/README.md
+++ b/githubusers/README.md
@@ -1,0 +1,73 @@
+# Github User Data Extractor
+
+## Description
+
+The Github User Data Extractor is a web-based tool that allows you to fetch publicly available information for specified GitHub users. You can input multiple GitHub usernames or profile URLs, and the tool will display their data in a structured table. This data can then be easily exported as a CSV file or copied to your clipboard for pasting into spreadsheet applications like Excel.
+
+## Features
+
+*   **Flexible Input:** Accepts GitHub usernames (e.g., `username`, `@username`) or full GitHub profile URLs (e.g., `https://github.com/username`).
+*   **Comprehensive Data Display:** Shows key user information including:
+    *   Avatar image
+    *   Name, bio, company, location
+    *   Contact details (email, blog, Twitter username)
+    *   Public activity statistics (repositories, gists, followers, following)
+    *   Account creation and last update dates
+*   **Readable Formatting:**
+    *   Dates (like `created_at`, `updated_at`) are displayed in a user-friendly format (e.g., "Wed, May 29, 2024").
+    *   Numbers (like repository counts, followers) are formatted with thousands separators for easy reading.
+*   **Export Options:**
+    *   **Download CSV:** Saves all extracted user data to a `github_users.csv` file.
+    *   **Copy to Excel:** Copies the data in a tab-separated format (TSV) suitable for pasting directly into Excel or other spreadsheet software.
+*   **GitHub Token Support:** Optionally, you can provide a GitHub Personal Access Token (PAT) to benefit from higher API rate limits, which is useful when fetching data for many users.
+
+## How to Use
+
+1.  **Open the Tool:**
+    *   Navigate to the `githubusers` directory.
+    *   Open the `index.html` file in your web browser (e.g., Chrome, Firefox, Edge).
+
+2.  **Enter GitHub Usernames or URLs:**
+    *   In the "Enter GitHub Usernames or URLs (one per line)" textarea, input the GitHub users you want to fetch data for. You can enter:
+        *   Plain usernames (e.g., `octocat`)
+        *   Usernames with an "@" prefix (e.g., `@google`)
+        *   Full profile URLs (e.g., `https://github.com/microsoft`)
+        *   GitHub Pages URLs (e.g., `username.github.io`)
+    *   Each input should be on a new line.
+
+3.  **Enter GitHub Token (Optional):**
+    *   If you have a GitHub Personal Access Token and wish to use it (for higher API rate limits), paste it into the "Enter GitHub Token" field. Otherwise, leave this field blank.
+
+4.  **Extract Data:**
+    *   Click the "Extract User Data" button.
+    *   The tool will fetch the data and display it in a table below the form.
+    *   A progress bar will show the status if multiple users are being processed.
+
+5.  **Export Data:**
+    *   **Download CSV:** Click the "Download CSV" button to save the data as a CSV file.
+    *   **Copy to Excel:** Click the "Copy to Excel" button. A confirmation message will appear, and the data will be copied to your clipboard, ready to be pasted into a spreadsheet.
+
+## Displayed Fields
+
+The following fields are fetched, displayed in the table, and included in the exports:
+
+*   `source`: The original input string for the user (e.g., `octocat`, `https://github.com/octocat`).
+*   `html_url`: Link to the user's GitHub profile.
+*   `avatar_url`: Link to the user's avatar image. (Displayed as an image in the table).
+*   `name`: The user's public name.
+*   `company`: The user's company.
+*   `blog`: Link to the user's blog or website.
+*   `location`: The user's public location.
+*   `email`: The user's public email address.
+*   `hireable`: Indicates if the user is marked as hireable (true/false or empty).
+*   `bio`: The user's biography.
+*   `twitter_username`: The user's Twitter username (if provided).
+*   `public_repos`: Number of public repositories.
+*   `public_gists`: Number of public gists.
+*   `followers`: Number of followers.
+*   `following`: Number of users the user is following.
+*   `created_at`: Date the user's account was created.
+*   `updated_at`: Date the user's account was last updated.
+
+---
+This README provides an overview of the tool, its features, and how to use it. For detailed manual testing steps, please refer to `TESTING_INSTRUCTIONS.md`.

--- a/githubusers/TESTING_INSTRUCTIONS.md
+++ b/githubusers/TESTING_INSTRUCTIONS.md
@@ -1,0 +1,181 @@
+# Manual Testing Instructions for Github User Data Extractor
+
+This document provides step-by-step instructions for manually testing the Github User Data Extractor application.
+
+## I. Prerequisites
+
+*   A modern web browser (e.g., Chrome, Firefox, Edge).
+*   (Optional) A GitHub Personal Access Token (PAT) to test authenticated requests. This allows for a higher API rate limit.
+*   (Optional) A spreadsheet program (e.g., Microsoft Excel, Google Sheets, LibreOffice Calc) to test the "Copy to Excel" functionality.
+
+## II. Testing Environment Setup
+
+1.  Open the `githubusers/index.html` file in your web browser.
+2.  You should see the "Github User Data Extractor" interface with an input field for a GitHub Token and a textarea for GitHub Usernames or URLs.
+
+## III. Test Cases
+
+### A. Input Testing
+
+**Objective:** Verify the application correctly parses and handles various input formats for GitHub users.
+
+**Test Steps:**
+
+1.  **Test Case A1: Single Valid GitHub Username**
+    *   In the "Enter GitHub Usernames or URLs" textarea, type a single valid GitHub username (e.g., `octocat`).
+    *   Click "Extract User Data".
+    *   **Expected Result:** Data for 'octocat' is fetched and displayed in the table. The 'source' column should show 'octocat'.
+
+2.  **Test Case A2: Single Valid GitHub Username with '@' prefix**
+    *   Clear previous inputs.
+    *   In the textarea, type a single valid GitHub username with an '@' prefix (e.g., `@google`).
+    *   Click "Extract User Data".
+    *   **Expected Result:** Data for 'google' is fetched and displayed. The 'source' column should show '@google'.
+
+3.  **Test Case A3: Single Valid GitHub Profile URL**
+    *   Clear previous inputs.
+    *   In the textarea, type a single valid GitHub profile URL (e.g., `https://github.com/microsoft`).
+    *   Click "Extract User Data".
+    *   **Expected Result:** Data for 'microsoft' is fetched and displayed. The 'source' column should show `https://github.com/microsoft`.
+
+4.  **Test Case A4: Single Valid GitHub Pages URL**
+    *   Clear previous inputs.
+    *   In the textarea, type a single valid GitHub Pages URL (e.g., `facebook.github.io`).
+    *   Click "Extract User Data".
+    *   **Expected Result:** Data for 'facebook' is fetched and displayed. The 'source' column should show `facebook.github.io`.
+
+5.  **Test Case A5: Mix of Multiple Valid Inputs**
+    *   Clear previous inputs.
+    *   In the textarea, type a mix of valid inputs, each on a new line:
+        ```
+        octocat
+        @google
+        https://github.com/microsoft
+        facebook.github.io
+        ```
+    *   Click "Extract User Data".
+    *   **Expected Result:** Data for all four users (octocat, google, microsoft, facebook) is fetched and displayed in the table. The 'source' column should reflect each input line.
+
+6.  **Test Case A6: Invalid Inputs and Blank Lines**
+    *   Clear previous inputs.
+    *   In the textarea, type a mix of invalid inputs, blank lines, and valid inputs:
+        ```
+        octocat
+        
+        thisisnotauser123456789
+        https://github.com/!@#$%^
+        @microsoft
+        ```
+    *   Click "Extract User Data".
+    *   **Expected Result:**
+        *   An alert message should appear for "thisisnotauser123456789" (e.g., "Failed to fetch data for thisisnotauser123456789...").
+        *   An alert message might appear for "https://github.com/!@#$%^" or it might be filtered out by the regex. If filtered, it's ignored. If processed, an error alert is expected.
+        *   Data for 'octocat' and 'microsoft' should be fetched and displayed correctly.
+        *   Blank lines should be ignored.
+
+7.  **Test Case A7: With GitHub Token (Optional)**
+    *   If you have a GitHub PAT, enter it into the "Enter GitHub Token" field.
+    *   Repeat Test Case A5.
+    *   **Expected Result:** Data for all users is fetched and displayed. Using a token might prevent API rate limit issues for extensive testing.
+
+8.  **Test Case A8: Without GitHub Token**
+    *   Ensure the "Enter GitHub Token" field is empty.
+    *   Repeat Test Case A1.
+    *   **Expected Result:** Data for 'octocat' is fetched. If you encounter API rate limit errors during extensive testing without a token, this is expected.
+
+### B. Output Table Display Testing
+
+**Objective:** Verify the data table displays the correct information in the correct format.
+
+**Test Steps:**
+
+1.  Perform a successful data extraction (e.g., using Test Case A5).
+2.  Examine the displayed table:
+    *   **B1: Field Order and Presence:**
+        *   Verify the columns appear in this exact order: `source`, `html_url`, `avatar_url`, `name`, `company`, `blog`, `location`, `email`, `hireable`, `bio`, `twitter_username`, `public_repos`, `public_gists`, `followers`, `following`, `created_at`, `updated_at`.
+        *   Verify no other columns are present.
+    *   **B2: Avatar URL (`avatar_url`)**
+        *   Verify the `avatar_url` column displays an image (the user's avatar). The image should be small (approx 50x50px) and have rounded corners.
+    *   **B3: Clickable Links (`html_url`, `blog`, `email`, `twitter_username`)**
+        *   `html_url`: Verify the URL is a clickable link opening the user's GitHub profile in a new tab.
+        *   `blog`: Verify the URL (if present) is a clickable link opening the user's blog in a new tab. Test with a user who has a blog listed (e.g., `torvalds`). If the blog URL doesn't start with `http://` or `https://`, verify it's prepended with `http://`.
+        *   `email`: Verify the email address (if present) is a clickable `mailto:` link.
+        *   `twitter_username`: Verify the Twitter username (if present) is displayed as `@username` and is a clickable link to their Twitter profile (e.g., `https://twitter.com/username`).
+    *   **B4: Date Formatting (`created_at`, `updated_at`)**
+        *   Verify dates in these columns are formatted like: "Wed, May 29, 2024" (Day, Month Date, Year).
+    *   **B5: Number Formatting (`public_repos`, `public_gists`, `followers`, `following`)**
+        *   Verify numbers in these columns are formatted with commas as thousands separators (e.g., "1,234").
+    *   **B6: Missing Fields**
+        *   For users who do not have certain information (e.g., no blog, no email, no bio), verify the corresponding cell in the table is empty.
+
+### C. Button Functionality Testing
+
+**Objective:** Verify the "Download CSV" and "Copy to Excel" buttons work as expected.
+
+**Test Steps:**
+
+1.  Perform a successful data extraction (e.g., using Test Case A5).
+2.  **Test Case C1: Download CSV**
+    *   Click the "Download CSV" button.
+    *   **Expected Result:** A file named `github_users.csv` is downloaded.
+    *   Open the downloaded CSV file with a text editor or spreadsheet program.
+    *   Verify:
+        *   The first row contains the headers in the correct order (as specified in B1).
+        *   Subsequent rows contain data for each user.
+        *   Data matches what was displayed in the HTML table (for fields like name, bio, etc.).
+        *   `created_at` and `updated_at` fields contain the formatted date strings (e.g., "Wed, May 29, 2024").
+        *   `public_repos`, `public_gists`, `followers`, `following` fields contain formatted number strings (e.g., "1,234").
+        *   `html_url`, `avatar_url`, `blog`, `email`, `twitter_username` fields contain the raw URLs or data (e.g., `https://github.com/octocat`, not HTML tags like `<a>` or `<img>`).
+
+3.  **Test Case C2: Copy to Excel**
+    *   Click the "Copy to Excel" button.
+    *   An alert should confirm "Results copied to clipboard!".
+    *   Open a spreadsheet program (Excel, Google Sheets, etc.).
+    *   Paste the content (Ctrl+V or Cmd+V).
+    *   **Expected Result:**
+        *   Data is pasted into the spreadsheet, correctly separated into columns.
+        *   The first row contains the headers in the correct order (as specified in B1).
+        *   Data matches what was displayed in the HTML table.
+        *   `created_at` and `updated_at` fields contain the formatted date strings.
+        *   `public_repos`, `public_gists`, `followers`, `following` fields contain formatted number strings.
+        *   `html_url`, `avatar_url`, `blog`, `email`, `twitter_username` fields contain the raw URLs or data.
+
+### D. Alerts and Messages Testing
+
+**Objective:** Verify appropriate feedback messages are shown to the user.
+
+**Test Steps:**
+
+1.  **Test Case D1: No Valid Inputs**
+    *   Clear the textarea or enter only invalid text (e.g., "this is not a valid user @#$").
+    *   Click "Extract User Data".
+    *   **Expected Result:** An alert message like "No valid GitHub URLs found!" is displayed.
+
+2.  **Test Case D2: Fetching Data Progress**
+    *   Enter a few valid usernames (e.g., `octocat`, `torvalds`, `microsoft`).
+    *   Click "Extract User Data".
+    *   **Expected Result:** While data is being fetched, an alert message like "<i class="bi bi-arrow-repeat"></i> Fetching data for 3 users..." is displayed, along with a progress bar.
+
+3.  **Test Case D3: Data Fetched Successfully**
+    *   After data is successfully fetched (from Test Case D2).
+    *   **Expected Result:** The progress alert is replaced by a success message like "Data fetched successfully! Click 'Copy to Excel' or 'Download CSV'."
+
+4.  **Test Case D4: User Not Found / API Error**
+    *   In the textarea, enter a valid username and a non-existent username (e.g., `octocat`, `thisuserdoesnotexist1234567`).
+    *   Click "Extract User Data".
+    *   **Expected Result:**
+        *   Data for `octocat` is displayed.
+        *   An error alert message is shown for the non-existent user (e.g., "Failed to fetch data for thisuserdoesnotexist1234567: Not Found").
+
+## IV. Reporting Issues
+
+If any of the actual results do not match the expected results, please document the issue with:
+*   Test Case ID (e.g., A1, B2).
+*   Steps to reproduce the issue.
+*   Expected result.
+*   Actual result.
+*   Any relevant screenshots.
+
+---
+End of Testing Instructions
+---

--- a/githubusers/index.html
+++ b/githubusers/index.html
@@ -19,19 +19,34 @@
   <div class="container py-4">
     <h1 class="mb-4"><i class="bi bi-github"></i> Github User Data Extractor</h1>
 
+    <p class="lead">
+      This tool extracts publicly available information about GitHub users.
+      Enter a GitHub personal access token (PAT) with appropriate permissions,
+      then provide a list of GitHub usernames or URLs (one per line).
+      The tool will fetch details like name, bio, followers, etc., and display them in a table.
+      You can then download the data as a CSV file or copy it to Excel.
+    </p>
+
     <form id="urlForm" class="mb-4">
       <div class="mb-3">
         <label for="token" class="form-label">Enter GitHub Token</label>
         <input type="text" class="form-control" id="token" placeholder="GitHub Token" />
       </div>
       <div class="mb-3">
-        <label for="urls" class="form-label">Enter GitHub URLs (one per line)</label>
+        <label for="urls" class="form-label">Enter GitHub Usernames or URLs (one per line)</label>
         <textarea class="form-control" id="urls" rows="5" placeholder="e.g.:
+username
 https://github.com/username
 https://username.github.io/"></textarea>
       </div>
       <button type="submit" class="btn btn-primary">
         <i class="bi bi-search"></i> Extract User Data
+      </button>
+      <button type="button" id="downloadCsvBtn" class="btn btn-success ms-2">
+        <i class="bi bi-download"></i> Download CSV
+      </button>
+      <button type="button" id="copyToExcelBtn" class="btn btn-info ms-2">
+        <i class="bi bi-clipboard"></i> Copy to Excel
       </button>
     </form>
 

--- a/githubusers/script.js
+++ b/githubusers/script.js
@@ -2,6 +2,29 @@ const form = document.getElementById("urlForm");
 const alertsDiv = document.getElementById("alerts");
 const results = document.getElementById("results");
 
+let userDataStorage = []; // To store fetched and processed user data
+
+// Define the order and selection of fields
+const SELECTED_FIELDS = [
+  "source",
+  "html_url",
+  "avatar_url",
+  "name",
+  "company",
+  "blog",
+  "location",
+  "email",
+  "hireable",
+  "bio",
+  "twitter_username",
+  "public_repos",
+  "public_gists",
+  "followers",
+  "following",
+  "created_at",
+  "updated_at",
+];
+
 function showAlert(message, type = "info", autoClose = false) {
   alertsDiv.insertAdjacentHTML(
     "beforeend",
@@ -15,12 +38,19 @@ function showAlert(message, type = "info", autoClose = false) {
   return alert;
 }
 
-const githubComRegex = /github\.com\/([a-zA-Z0-9-]+)/;
-const githubIoRegex = /([a-zA-Z0-9-]+)\.github\.io/;
+const githubComRegex = /github\.com\/([a-zA-Z0-9_-]+)/i;
+const githubIoRegex = /([a-zA-Z0-9_-]+)\.github\.io/i;
+const plainUsernameRegex = /^@?([a-zA-Z0-9_-]+)$/i; // Allows optional @ prefix
+
 const extractUser = (text) => {
+  if (!text) return null;
   const matchCom = text.match(githubComRegex);
+  if (matchCom) return matchCom[1];
   const matchIo = text.match(githubIoRegex);
-  return matchCom ? matchCom[1] : matchIo ? matchIo[1] : null;
+  if (matchIo) return matchIo[1];
+  const matchPlain = text.match(plainUsernameRegex);
+  if (matchPlain) return matchPlain[1];
+  return null;
 };
 
 async function fetchUserData(username, token) {
@@ -32,15 +62,21 @@ async function fetchUserData(username, token) {
 }
 
 function escapeCell(value) {
+  const stringValue = String(value); // Ensure value is a string
   // If the cell contains a tab or newline, wrap it in quotes. Escape quotes with ""
-  return /[\t\n]/.test(value) ? `"${value.replace(/"/g, '""')}"` : value;
+  return /[\t\n]/.test(stringValue) ? `"${stringValue.replace(/"/g, '""')}"` : stringValue;
 }
 
 function convertToTSV(data) {
-  const headers = Object.keys(data[0]);
+  const headers = SELECTED_FIELDS; // Use SELECTED_FIELDS for consistent header order
   const rows = [
     headers.join("\t"),
-    ...data.map((user) => headers.map((header) => escapeCell(user[header] || "")).join("\t")),
+    ...data.map((user) => 
+      headers.map((header) => {
+        const value = user[header] === null || user[header] === undefined ? "" : user[header];
+        return escapeCell(value); // escapeCell will handle string conversion
+      }).join("\t")
+    ),
   ];
   return rows.join("\n");
 }
@@ -53,6 +89,7 @@ form.addEventListener("submit", async (e) => {
   e.preventDefault();
   alertsDiv.innerHTML = "";
   results.innerHTML = "";
+  userDataStorage = []; // Clear previous results
 
   const token = document.getElementById("token").value.trim();
   const text = document.getElementById("urls").value;
@@ -68,7 +105,7 @@ form.addEventListener("submit", async (e) => {
     "info"
   );
 
-  const userData = [];
+  let fetchedDataArray = []; // Temporary array for raw fetched data
   try {
     alertsDiv.insertAdjacentHTML(
       "beforeend",
@@ -81,41 +118,150 @@ form.addEventListener("submit", async (e) => {
 
     for (const { source, username } of input) {
       try {
-        userData.push({ source, ...(await fetchUserData(username, token)) });
-        const progressPercent = (userData.length / input.length) * 100;
+        const rawData = await fetchUserData(username, token);
+        const processedUser = { source };
+        SELECTED_FIELDS.slice(1).forEach(field => { // slice(1) to skip 'source'
+          let value = rawData[field] === null || rawData[field] === undefined ? "" : rawData[field];
+          
+          // Date Formatting for userDataStorage
+          if (["created_at", "updated_at"].includes(field) && value) {
+            try {
+              value = new Date(value).toLocaleDateString('en-US', { 
+                weekday: 'short', year: 'numeric', month: 'short', day: 'numeric' 
+              });
+            } catch (dateError) {
+              console.error(`Error formatting date for ${field}: ${value}`, dateError);
+              // Keep original value (or empty string) if formatting fails
+              value = rawData[field] === null || rawData[field] === undefined ? "" : rawData[field]; // Revert to original if error
+            }
+          } 
+          // Number Formatting for userDataStorage
+          else if (["public_repos", "public_gists", "followers", "following"].includes(field) && typeof value === 'number') {
+            value = value.toLocaleString('en-US');
+          }
+          // For other fields (html_url, blog, email, twitter_username, avatar_url, etc.),
+          // store the raw value in userDataStorage.
+          processedUser[field] = value;
+        });
+        fetchedDataArray.push(processedUser);
+        
+        const progressPercent = (fetchedDataArray.length / input.length) * 100;
         progressBarInner.style.width = `${progressPercent}%`;
-        progressBarInner.textContent = `${userData.length}/${input.length}`;
+        progressBarInner.textContent = `${fetchedDataArray.length}/${input.length}`;
       } catch (error) {
         showAlert(error.message, "danger");
       }
     }
+    userDataStorage = fetchedDataArray; // Store processed data
 
-    if (userData.length > 0) {
-      const headers = Object.keys(userData[0]);
+    if (userDataStorage.length > 0) {
+      // Display results in table
       results.innerHTML = /* html */ `<table class="table table-striped">
-            <thead><tr>${headers.map((header) => `<th>${header}</th>`).join("")}</tr></thead>
+            <thead><tr>${SELECTED_FIELDS.map((header) => `<th>${header}</th>`).join("")}</tr></thead>
             <tbody>
-              ${userData
-                .map(
-                  (user) =>
-                    `<tr>${Object.entries(user)
-                      .map(([key, value]) => `<td>${value || ""}</td>`)
-                      .join("")}</tr>`
-                )
+              ${userDataStorage
+                .map((user) => {
+                  const cells = SELECTED_FIELDS.map((field) => {
+                    // user[field] already has dates/numbers formatted as per userDataStorage modifications.
+                    // For link/image fields, user[field] contains the raw URL or username.
+                    const cellData = user[field] === null || user[field] === undefined ? "" : user[field];
+                    let displayHtml = cellData;
+
+                    if (field === "html_url" && cellData) {
+                      displayHtml = `<a href="${cellData}" target="_blank">${cellData}</a>`;
+                    } else if (field === "blog" && cellData) {
+                      let blogUrl = cellData;
+                      if (!blogUrl.startsWith('http://') && !blogUrl.startsWith('https://')) {
+                        blogUrl = `http://${blogUrl}`;
+                      }
+                      displayHtml = `<a href="${blogUrl}" target="_blank">${cellData}</a>`;
+                    } else if (field === "email" && cellData) {
+                      displayHtml = `<a href="mailto:${cellData}">${cellData}</a>`;
+                    } else if (field === "twitter_username" && cellData) {
+                      displayHtml = `<a href="https://twitter.com/${cellData}" target="_blank">@${cellData}</a>`;
+                    } else if (field === "avatar_url" && cellData) {
+                      displayHtml = `<img src="${cellData}" alt="${user.name || 'Avatar'}" width="50" height="50" style="border-radius: 50%;">`;
+                    }
+                    return `<td>${displayHtml}</td>`;
+                  }).join("");
+                  return `<tr>${cells}</tr>`;
+                })
                 .join("")}
             </tbody>
           </table>`;
-      const tsv = convertToTSV(userData);
-      await copyToClipboard(tsv);
-
+      
       progressAlert.remove();
       showAlert(
-        '<i class="bi bi-clipboard-check"></i> Results copied to clipboard! You can paste into Excel.',
-        "success",
-        true
+        "Data fetched successfully! Click 'Copy to Excel' or 'Download CSV'.",
+        "success"
       );
+    } else {
+      progressAlert.remove();
+      if (alertsDiv.children.length === 0) { // Only show if no other errors
+        showAlert("No user data processed. Check inputs or token.", "warning");
+      }
     }
   } catch (error) {
     showAlert(`Unexpected error: ${error.message}`, "danger");
+    if (progressAlert) progressAlert.remove();
   }
 });
+
+// Event listener for Download CSV button
+const downloadCsvBtn = document.getElementById("downloadCsvBtn");
+downloadCsvBtn.addEventListener("click", () => {
+  if (userDataStorage.length === 0) {
+    showAlert("No data to download.", "warning", true);
+    return;
+  }
+  const csv = convertToCSV(userDataStorage);
+  const blob = new Blob([csv], { type: "text/csv;charset=utf-8;" });
+  const link = document.createElement("a");
+  const url = URL.createObjectURL(blob);
+  link.setAttribute("href", url);
+  link.setAttribute("download", "github_users.csv");
+  link.style.visibility = "hidden";
+  document.body.appendChild(link);
+  link.click();
+  document.body.removeChild(link);
+  showAlert("CSV downloaded.", "success", true);
+});
+
+// Event listener for Copy to Excel button
+const copyToExcelBtn = document.getElementById("copyToExcelBtn");
+copyToExcelBtn.addEventListener("click", async () => {
+  if (userDataStorage.length === 0) {
+    showAlert("No data to copy.", "warning", true);
+    return;
+  }
+  try {
+    const tsv = convertToTSV(userDataStorage);
+    await copyToClipboard(tsv);
+    showAlert("Results copied to clipboard! You can paste into Excel.", "success", true);
+  } catch (error) {
+    showAlert(`Error copying to clipboard: ${error.message}`, "danger");
+  }
+});
+
+// Helper function to convert data to CSV format
+function convertToCSV(data) {
+  const headers = SELECTED_FIELDS;
+  const rows = [
+    headers.join(","), // CSV headers
+    ...data.map((user) =>
+      headers
+        .map((header) => escapeCellCSV(user[header] === null || user[header] === undefined ? "" : user[header]))
+        .join(",")
+    ),
+  ];
+  return rows.join("\n");
+}
+
+// Adapted escapeCell for CSV: fields with comma, quote, or newline are quoted. Quotes are doubled.
+function escapeCellCSV(value) {
+  const stringValue = String(value); // Ensure value is a string
+  if (/[",\n]/.test(stringValue)) {
+    return `"${stringValue.replace(/"/g, '""')}"`;
+  }
+  return stringValue;
+}


### PR DESCRIPTION
I've made several enhancements to the GitHub User Data Extractor:

- You can now input GitHub usernames (e.g., @username or username) in addition to full URLs.
- I've added a clear description of its functionality at the top of the page.
- The displayed and exported user data is now filtered to a specific set of fields: html_url, avatar_url, name, company, blog, location, email, hireable, bio, twitter_username, public_repos, public_gists, followers, following, created_at, updated_at. The original input 'source' is also included.
- Dates (e.g., "Wed, May 28, 2025") and numbers (with commas) are now formatted for better readability in the displayed table and exports.
- The avatar_url is now rendered as an image in the table.
- html_url, blog, email, and twitter_username are now clickable links in the table.
- I've added "Download CSV" and "Copy to Excel" buttons for exporting the extracted data.
- Automatic clipboard copy on data fetch has been removed; copying now requires a button click.
- I've included a new `TESTING_INSTRUCTIONS.md` for manual verification.
- I've also added a comprehensive `README.md` for the tool.

Source: https://jules.google.com/task/15795358620870007793