### PR TITLE
feat: Add Hacker News Links Extractor

### DIFF
--- a/hnlinks/index.html
+++ b/hnlinks/index.html
@@ -1,0 +1,61 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <title>Hacker News Links Extractor</title>
+  <link href="https://cdn.jsdelivr.net/npm/bootstrap@5.3.6/dist/css/bootstrap.min.css" rel="stylesheet" crossorigin="anonymous">
+  <link href="https://cdn.jsdelivr.net/npm/bootstrap-icons@1.11.3/font/bootstrap-icons.css" rel="stylesheet" crossorigin="anonymous">
+  <style>
+    /* Add any custom styles here if needed */
+  </style>
+</head>
+<body>
+  <div class="container py-4">
+    <header class="pb-3 mb-4 border-bottom">
+      <a href="/" class="d-flex align-items-center text-dark text-decoration-none">
+        <i class="bi bi-link-45deg fs-2 me-2"></i>
+        <span class="fs-4">Hacker News Links Extractor</span>
+      </a>
+    </header>
+
+    <p class="lead">Select a Hacker News source and click "Scrape Links" to extract article URLs.</p>
+
+    <div class="row mb-3">
+      <div class="col-md-6">
+        <label for="sourceUrl" class="form-label">Select Source:</label>
+        <select class="form-select" id="sourceUrl">
+          <option value="https://news.ycombinator.com">Hacker News (news.ycombinator.com)</option>
+          <option value="https://www.hntoplinks.com/">HN Top Links (hntoplinks.com)</option>
+          <option value="https://www.hntoplinks.com/week">HN Top Links - Week (hntoplinks.com/week)</option>
+          <option value="https://www.hntoplinks.com/month">HN Top Links - Month (hntoplinks.com/month)</option>
+        </select>
+      </div>
+    </div>
+
+    <button class="btn btn-primary mb-3" id="scrapeButton">
+      <i class="bi bi-search me-1"></i> Scrape Links
+    </button>
+
+    <div class="mb-3">
+      <label for="linksTextArea" class="form-label">Extracted Links:</label>
+      <textarea class="form-control" id="linksTextArea" rows="10" readonly></textarea>
+    </div>
+
+    <button class="btn btn-secondary mb-3" id="copyButton">
+      <i class="bi bi-clipboard me-1"></i> Copy to Clipboard
+    </button>
+
+    <div id="loadingIndicator" class="d-none">
+      <div class="spinner-border text-primary" role="status">
+        <span class="visually-hidden">Loading...</span>
+      </div>
+      <p class="ms-2 d-inline-block">Scraping links, please wait...</p>
+    </div>
+
+  </div>
+
+  <script src="https://cdn.jsdelivr.net/npm/bootstrap@5.3.6/dist/js/bootstrap.bundle.min.js" crossorigin="anonymous"></script>
+  <script src="script.js"></script>
+</body>
+</html>

--- a/hnlinks/script.js
+++ b/hnlinks/script.js
@@ -1,0 +1,146 @@
+document.addEventListener('DOMContentLoaded', () => {
+  const sourceUrlSelect = document.getElementById('sourceUrl');
+  const scrapeButton = document.getElementById('scrapeButton');
+  const linksTextArea = document.getElementById('linksTextArea');
+  const copyButton = document.getElementById('copyButton');
+  const loadingIndicator = document.getElementById('loadingIndicator');
+
+  const PROXY_BASE = 'https://llmfoundry.straive.com/-/proxy/';
+
+  async function fetchAndParse(url) {
+    const proxyUrl = PROXY_BASE + url;
+    const response = await fetch(proxyUrl);
+    if (!response.ok) {
+      throw new Error(`Failed to fetch ${url}: ${response.statusText}`);
+    }
+    const htmlText = await response.text();
+    const parser = new DOMParser();
+    return parser.parseFromString(htmlText, 'text/html');
+  }
+
+  function getAbsoluteUrl(baseUrl, relativeUrl) {
+    try {
+      return new URL(relativeUrl, baseUrl).href;
+    } catch (e) {
+      // Handle cases where relativeUrl might be malformed or already absolute in a weird way
+      if (relativeUrl.startsWith('http://') || relativeUrl.startsWith('https://')) {
+        return relativeUrl;
+      }
+      console.warn(`Could not form absolute URL for base: ${baseUrl}, relative: ${relativeUrl}`);
+      return relativeUrl; // fallback
+    }
+  }
+
+  scrapeButton.addEventListener('click', async () => {
+    const selectedUrl = sourceUrlSelect.value;
+    linksTextArea.value = ''; // Clear previous results
+    loadingIndicator.classList.remove('d-none');
+    scrapeButton.disabled = true;
+
+    try {
+      const doc = await fetchAndParse(selectedUrl);
+      let extractedLinks = [];
+      const siteOrigin = new URL(selectedUrl).origin;
+
+      if (selectedUrl.includes('news.ycombinator.com')) {
+        const links = doc.querySelectorAll('span.titleline > a');
+        links.forEach(link => {
+          const title = link.textContent.trim();
+          const href = link.getAttribute('href');
+          if (href && !title.startsWith('Ask HN:') && !title.startsWith('Show HN:') && !href.startsWith('from?site=')) {
+            // Check if it's an internal HN link like item?id=
+            // These are kept as they are discussion links for self-posts
+             if (href.startsWith('item?id=')) {
+               extractedLinks.push(getAbsoluteUrl('https://news.ycombinator.com/', href));
+             } else if (href.startsWith('http://') || href.startsWith('https://')) {
+               extractedLinks.push(href);
+             } else {
+               // Relative path, likely an internal page not caught, but attempt to make absolute
+               extractedLinks.push(getAbsoluteUrl(siteOrigin, href));
+             }
+          }
+        });
+      } else if (selectedUrl.includes('hntoplinks.com')) {
+        // This selector is more generic and relies on filtering.
+        // It assumes articles are in some main content area.
+        // A more specific selector would be better if the structure was known.
+        // For now, we find all links within what seems to be the main content area.
+        // Looking at the text output, stories are listed one by one.
+        // Let's try to target links that are likely titles.
+        // The text output showed links like `[9]My AI skeptic friends are all nuts (fly.io)`
+        // These are `<a>` tags. We need to avoid comment links and user links.
+        const allLinks = doc.querySelectorAll('a[href]'); // Broad selector, needs careful filtering
+
+        allLinks.forEach(link => {
+          const href = link.getAttribute('href');
+          const text = link.textContent.trim();
+
+          if (!href || href === '#' || href.startsWith('javascript:')) return;
+
+          // Filter out navigation, user profiles, comments, etc.
+          if (href.includes('news.ycombinator.com/user?id=')) return;
+          if (href.includes('news.ycombinator.com/item?id=')) return; // These are comment links on hntoplinks
+          if (href.startsWith('/subscribers') || href.startsWith('/stories/') || href.startsWith('/about')) return;
+          if (href.startsWith('/today?page=') || href.startsWith('/week?page=') || href.startsWith('/month?page=')) return;
+          if (text.match(/^\d{4}$/) || ['Today', 'This Week', 'This Month', 'This Year', 'All', 'Subscribe', 'Next »', 'About'].includes(text)) return;
+          if (text.startsWith('Ask HN:') || text.startsWith('Show HN:')) return;
+
+          // Ensure the link is not part of the site's own chrome/navigation
+          // This is tricky without seeing the full structure.
+          // We assume main article links don't have obvious nav classes or IDs.
+          // A simple check: if the parent is a nav element, skip.
+          let parent = link.parentElement;
+          let isNav = false;
+          for(let i=0; i<3; ++i) { // Check up to 3 levels for nav, header, footer
+            if (!parent) break;
+            if (parent.tagName === 'NAV' || parent.tagName === 'HEADER' || parent.tagName === 'FOOTER' || parent.id === 'nav' || parent.classList.contains('nav')) {
+              isNav = true;
+              break;
+            }
+            parent = parent.parentElement;
+          }
+          if(isNav) return;
+
+          // If it's a relative link, make it absolute from hntoplinks.com
+          extractedLinks.push(getAbsoluteUrl(siteOrigin, href));
+        });
+      }
+
+      // Remove duplicates and display
+      const uniqueLinks = [...new Set(extractedLinks)];
+      linksTextArea.value = uniqueLinks.join('\n');
+      if (uniqueLinks.length === 0) {
+        linksTextArea.value = 'No article links found matching the criteria.';
+      }
+
+    } catch (error) {
+      console.error('Error scraping links:', error);
+      linksTextArea.value = `Error: ${error.message}`;
+      alert(`An error occurred: ${error.message}`);
+    } finally {
+      loadingIndicator.classList.add('d-none');
+      scrapeButton.disabled = false;
+    }
+  });
+
+  copyButton.addEventListener('click', () => {
+    if (linksTextArea.value) {
+      navigator.clipboard.writeText(linksTextArea.value)
+        .then(() => {
+          const originalText = copyButton.innerHTML;
+          copyButton.innerHTML = '<i class="bi bi-check-lg me-1"></i> Copied!';
+          copyButton.classList.remove('btn-secondary');
+          copyButton.classList.add('btn-success');
+          setTimeout(() => {
+            copyButton.innerHTML = originalText;
+            copyButton.classList.remove('btn-success');
+            copyButton.classList.add('btn-secondary');
+          }, 2000);
+        })
+        .catch(err => {
+          console.error('Failed to copy links:', err);
+          alert('Failed to copy links to clipboard. See console for details.');
+        });
+    }
+  });
+});

--- a/tools.json
+++ b/tools.json
@@ -91,6 +91,12 @@
       "url": "hackernewsmd"
     },
     {
+      "icon": "bi-newspaper",
+      "title": "Hacker News Links Extractor",
+      "description": "Scrape main article links from Hacker News or HN Top Links.",
+      "url": "hnlinks"
+    },
+    {
       "icon": "bi-geo-alt",
       "title": "What's Near Me?",
       "description": "Find nearby attractions and places of interest.",


### PR DESCRIPTION
This commit introduces a new way to scrape article links from Hacker News and HN Top Links.

Key features:
- Allows you to select from four sources:
  - news.ycombinator.com
  - hntoplinks.com (daily, weekly, monthly)
- Fetches website content.
- Parses HTML to extract main article links.
  - Specific selectors for news.ycombinator.com.
  - Heuristic filtering for hntoplinks.com.
- Displays extracted links in a textarea.
- Provides a "Copy to Clipboard" button for the extracted links.
- Includes a loading indicator during scraping.
- Added to the main listing.

The implementation is client-side JavaScript, located in the new `hnlinks` directory.
Manual testing should verify link accuracy from all sources and the robustness of the filtering, especially for hntoplinks.com.