### PR TITLE
Add LLM fill comparison

### DIFF
--- a/llmfill/index.html
+++ b/llmfill/index.html
@@ -1,0 +1,81 @@
+<!doctype html>
+<html lang="en">
+  <head>
+    <meta charset="UTF-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <title>LLM Fill in the Blank</title>
+    <link href="https://cdn.jsdelivr.net/npm/bootstrap@5.3.6/dist/css/bootstrap.min.css" rel="stylesheet" crossorigin="anonymous" />
+    <link href="https://cdn.jsdelivr.net/npm/bootstrap-icons@1.11.0/font/bootstrap-icons.css" rel="stylesheet" crossorigin="anonymous" />
+  </head>
+  <body class="container py-5">
+    <h1 class="mb-4"><i class="bi bi-pencil"></i> LLM Fill in the Blank</h1>
+    <div class="row g-3 mb-3">
+      <div class="col-md-4">
+        <label for="modelInput" class="form-label">Model</label>
+        <input id="modelInput" class="form-control" list="modelList" value="openai/gpt-4o" />
+        <datalist id="modelList">
+          <option value="openai/gpt-4o" />
+          <option value="openai/gpt-4o-mini" />
+          <option value="anthropic/claude-3-opus-20240229" />
+          <option value="anthropic/claude-3-sonnet-20240229" />
+          <option value="anthropic/claude-3-haiku-20240307" />
+          <option value="meta-llama/llama-3-70b-instruct" />
+          <option value="meta-llama/llama-3-8b-instruct" />
+          <option value="mistralai/mistral-7b-instruct" />
+          <option value="nousresearch/nous-capybara-7b" />
+          <option value="meta-llama/llama-2-70b-chat" />
+        </datalist>
+      </div>
+      <div class="col-md-4">
+        <label for="baseUrlInput" class="form-label">Base URL</label>
+        <input id="baseUrlInput" class="form-control" type="url" value="https://aipipe.org/openrouter/v1" />
+      </div>
+      <div class="col-md-4">
+        <label for="apiKeyInput" class="form-label">API Key</label>
+        <input id="apiKeyInput" class="form-control" type="password" />
+      </div>
+    </div>
+
+    <ul class="nav nav-tabs" id="fill-tabs" role="tablist">
+      <li class="nav-item" role="presentation">
+        <button class="nav-link active" id="single-tab" data-bs-toggle="tab" data-bs-target="#single" type="button" role="tab" aria-controls="single" aria-selected="true">Single</button>
+      </li>
+      <li class="nav-item" role="presentation">
+        <button class="nav-link" id="compare-tab" data-bs-toggle="tab" data-bs-target="#compare" type="button" role="tab" aria-controls="compare" aria-selected="false">Compare</button>
+      </li>
+    </ul>
+
+    <div class="tab-content pt-3" id="fill-tab-content">
+      <div class="tab-pane fade show active" id="single" role="tabpanel" aria-labelledby="single-tab">
+        <div class="mb-3">
+          <label for="sentenceInput" class="form-label">Sentence</label>
+          <textarea id="sentenceInput" class="form-control" rows="2">The quick brown fox jumps over the lazy dog.</textarea>
+        </div>
+        <div id="tokensContainer" class="mb-3"></div>
+        <table id="logprobTable" class="table table-sm">
+          <thead>
+            <tr><th>Token</th><th>Log Prob</th></tr>
+          </thead>
+          <tbody></tbody>
+        </table>
+      </div>
+
+      <div class="tab-pane fade" id="compare" role="tabpanel" aria-labelledby="compare-tab">
+        <div class="mb-3">
+          <label for="sentenceA" class="form-label">Sentence A</label>
+          <textarea id="sentenceA" class="form-control" rows="2">The doctor said he was tired.</textarea>
+        </div>
+        <div id="tokensA" class="mb-3"></div>
+        <div class="mb-3">
+          <label for="sentenceB" class="form-label">Sentence B</label>
+          <textarea id="sentenceB" class="form-control" rows="2">The nurse said he was tired.</textarea>
+        </div>
+        <div id="tokensB" class="mb-3"></div>
+        <svg id="scatterPlot" width="600" height="400"></svg>
+      </div>
+    </div>
+
+    <script type="module" src="script.js"></script>
+    <script src="https://cdn.jsdelivr.net/npm/bootstrap@5.3.6/dist/js/bootstrap.bundle.min.js" crossorigin="anonymous"></script>
+  </body>
+</html>

--- a/llmfill/script.js
+++ b/llmfill/script.js
@@ -1,0 +1,238 @@
+import * as d3 from "https://cdn.jsdelivr.net/npm/d3@7/+esm";
+
+const sentenceInput = document.getElementById("sentenceInput");
+const tokensContainer = document.getElementById("tokensContainer");
+const logprobTableBody = document.querySelector("#logprobTable tbody");
+const sentenceAInput = document.getElementById("sentenceA");
+const sentenceBInput = document.getElementById("sentenceB");
+const tokensAContainer = document.getElementById("tokensA");
+const tokensBContainer = document.getElementById("tokensB");
+const scatterSvg = document.getElementById("scatterPlot");
+const modelInput = document.getElementById("modelInput");
+const baseUrlInput = document.getElementById("baseUrlInput");
+const apiKeyInput = document.getElementById("apiKeyInput");
+
+let tokens = [];
+let blankIndex = -1;
+let tokensA = [];
+let tokensB = [];
+let blankIndexA = -1;
+let blankIndexB = -1;
+
+function tokenize(text) {
+  return text.match(/\w+|[^\s\w]/g) || [];
+}
+
+function renderTokens() {
+  tokensContainer.innerHTML = "";
+  tokens.forEach((t, i) => {
+    const btn = document.createElement("button");
+    btn.type = "button";
+    btn.className = "btn btn-outline-secondary btn-sm m-1";
+    btn.textContent = i === blankIndex ? "____" : t;
+    btn.addEventListener("click", () => selectBlank(i));
+    tokensContainer.appendChild(btn);
+  });
+}
+
+function selectBlank(i) {
+  blankIndex = i;
+  renderTokens();
+  fetchCompletion();
+}
+
+function renderTokensCompare() {
+  tokensAContainer.innerHTML = "";
+  tokensA.forEach((t, i) => {
+    const btn = document.createElement("button");
+    btn.type = "button";
+    btn.className = "btn btn-outline-secondary btn-sm m-1";
+    btn.textContent = i === blankIndexA ? "____" : t;
+    btn.addEventListener("click", () => selectBlankCompare("A", i));
+    tokensAContainer.appendChild(btn);
+  });
+  tokensBContainer.innerHTML = "";
+  tokensB.forEach((t, i) => {
+    const btn = document.createElement("button");
+    btn.type = "button";
+    btn.className = "btn btn-outline-secondary btn-sm m-1";
+    btn.textContent = i === blankIndexB ? "____" : t;
+    btn.addEventListener("click", () => selectBlankCompare("B", i));
+    tokensBContainer.appendChild(btn);
+  });
+}
+
+function selectBlankCompare(which, i) {
+  if (which === "A") {
+    blankIndexA = i;
+  } else {
+    blankIndexB = i;
+  }
+  renderTokensCompare();
+  fetchComparison();
+}
+
+function init() {
+  tokens = tokenize(sentenceInput.value);
+  blankIndex = Math.floor(Math.random() * tokens.length);
+  renderTokens();
+  fetchCompletion();
+}
+
+sentenceInput.addEventListener("input", init);
+
+function initCompare() {
+  tokensA = tokenize(sentenceAInput.value);
+  tokensB = tokenize(sentenceBInput.value);
+  blankIndexA = Math.floor(Math.random() * tokensA.length);
+  blankIndexB = Math.floor(Math.random() * tokensB.length);
+  renderTokensCompare();
+  fetchComparison();
+}
+
+sentenceAInput?.addEventListener("input", initCompare);
+sentenceBInput?.addEventListener("input", initCompare);
+
+async function fetchCompletion() {
+  if (blankIndex === -1 || !apiKeyInput.value) return;
+  const prompt = tokens.map((t, i) => (i === blankIndex ? "____" : t)).join(" ");
+  const body = {
+    model: modelInput.value,
+    messages: [
+      {
+        role: "system",
+        content: "Return only the missing word in the user's sentence.",
+      },
+      { role: "user", content: prompt },
+    ],
+    max_tokens: 1,
+    logprobs: true,
+    top_logprobs: 5,
+    stream: false,
+  };
+
+  try {
+    const res = await fetch(`${baseUrlInput.value.replace(/\/$/, "")}/chat/completions`, {
+      method: "POST",
+      headers: {
+        "Content-Type": "application/json",
+        Authorization: `Bearer ${apiKeyInput.value}`,
+      },
+      body: JSON.stringify(body),
+    });
+    const data = await res.json();
+    const word = (data.choices?.[0]?.message?.content || data.choices?.[0]?.text || "").trim();
+    if (word) tokens[blankIndex] = word;
+    renderTokens();
+    const probs = data.choices?.[0]?.logprobs?.content?.[0]?.top_logprobs || {};
+    displayLogprobs(probs);
+  } catch (err) {
+    console.error(err);
+  }
+}
+
+function displayLogprobs(probs) {
+  logprobTableBody.innerHTML = "";
+  const entries = Object.entries(probs);
+  if (!entries.length) return;
+  const values = entries.map(([, p]) => p);
+  const scale = d3.scaleSequential(d3.interpolateBlues).domain([Math.min(...values), 0]);
+  entries.forEach(([token, prob]) => {
+    const row = document.createElement("tr");
+    row.innerHTML = `<td>${token}</td><td style="background-color:${scale(prob)}">${prob.toFixed(4)}</td>`;
+    logprobTableBody.appendChild(row);
+  });
+}
+
+async function fetchLogprobs(tokens, index) {
+  const prompt = tokens.map((t, i) => (i === index ? "____" : t)).join(" ");
+  const body = {
+    model: modelInput.value,
+    messages: [
+      {
+        role: "system",
+        content: "Return only the missing word in the user's sentence.",
+      },
+      { role: "user", content: prompt },
+    ],
+    max_tokens: 1,
+    logprobs: true,
+    top_logprobs: 50,
+    stream: false,
+  };
+
+  const res = await fetch(`${baseUrlInput.value.replace(/\/$/, "")}/chat/completions`, {
+    method: "POST",
+    headers: {
+      "Content-Type": "application/json",
+      Authorization: `Bearer ${apiKeyInput.value}`,
+    },
+    body: JSON.stringify(body),
+  });
+  const data = await res.json();
+  const word = (data.choices?.[0]?.message?.content || data.choices?.[0]?.text || "").trim();
+  if (word) tokens[index] = word;
+  return data.choices?.[0]?.logprobs?.content?.[0]?.top_logprobs || {};
+}
+
+async function fetchComparison() {
+  if (blankIndexA === -1 || blankIndexB === -1 || !apiKeyInput.value) return;
+  const [probsA, probsB] = await Promise.all([
+    fetchLogprobs(tokensA, blankIndexA),
+    fetchLogprobs(tokensB, blankIndexB),
+  ]);
+  renderTokensCompare();
+  drawScatter(probsA, probsB);
+}
+
+function drawScatter(probsA, probsB) {
+  const tokens = Object.keys(probsA).filter((t) => t in probsB);
+  scatterSvg.innerHTML = "";
+  if (!tokens.length) return;
+  const width = +scatterSvg.getAttribute("width");
+  const height = +scatterSvg.getAttribute("height");
+  const margin = 40;
+  const xVals = tokens.map((t) => probsA[t]);
+  const yVals = tokens.map((t) => probsB[t]);
+  const x = d3
+    .scaleLinear()
+    .domain([Math.min(...xVals), 0])
+    .range([margin, width - margin]);
+  const y = d3
+    .scaleLinear()
+    .domain([Math.min(...yVals), 0])
+    .range([height - margin, margin]);
+  const svg = d3.select(scatterSvg);
+  svg
+    .append("g")
+    .attr("transform", `translate(0,${height - margin})`)
+    .call(d3.axisBottom(x));
+  svg.append("g").attr("transform", `translate(${margin},0)`).call(d3.axisLeft(y));
+  svg
+    .selectAll("text.token")
+    .data(tokens)
+    .enter()
+    .append("text")
+    .attr("class", "token")
+    .attr("x", (d) => x(probsA[d]))
+    .attr("y", (d) => y(probsB[d]))
+    .text((d) => d)
+    .attr("font-size", "0.75rem")
+    .attr("text-anchor", "middle");
+  svg
+    .append("text")
+    .attr("x", width / 2)
+    .attr("y", height - 5)
+    .attr("text-anchor", "middle")
+    .text("Log prob A");
+  svg
+    .append("text")
+    .attr("transform", "rotate(-90)")
+    .attr("x", -height / 2)
+    .attr("y", 15)
+    .attr("text-anchor", "middle")
+    .text("Log prob B");
+}
+
+init();
+initCompare();

--- a/tools.json
+++ b/tools.json
@@ -192,6 +192,12 @@
       "description": "Evaluate quotes from different models and see which one wins",
       "url": "quotesarena",
       "created": "2025-03-30T09:18:58+08:00"
+    },
+    {
+      "icon": "bi-pen",
+      "title": "LLM Fill",
+      "description": "Blank out words and let LLMs fill them in with log probabilities.",
+      "url": "llmfill"
     }
   ]
 }


### PR DESCRIPTION
## Summary
- extend LLM Fill to include a comparison tab
- allow masking words in two sentences
- display log prob scatter plot for shared tokens

## Testing
- `npm run lint`
- `npm test --silent` *(fails: vitest not found)*

------
https://chatgpt.com/codex/tasks/task_e_68456b4e0154832c8ee629484066ea6d