### PR TITLE
Add LLM fill-in-the-blank demo

### DIFF
--- a/llmfill/README.md
+++ b/llmfill/README.md
@@ -1,0 +1,10 @@
+# LLM Fill-in-the-Blank
+
+Inspired by Google's [Fill in the Blank](https://pair.withgoogle.com/explorables/fill-in-the-blank/) experiment, this tool lets you hide any word in a sentence and see how different language models predict the missing text. As you blank a word, the app asks the model to fill it in and shows the top token probabilities coloured from white (likely) to red (unlikely).
+
+1. Type or edit the sentence in the text box.
+2. Each word or punctuation mark appears as a button below it.
+3. Click a button to blank the word. A request is sent to the selected model and the word is replaced with the model's guess.
+4. The probabilities for the predicted tokens are shown in tables beside each other.
+
+You can supply your own API key, base URL and model. The data is stored in your browser using `saveform`.

--- a/llmfill/index.html
+++ b/llmfill/index.html
@@ -1,0 +1,132 @@
+<!doctype html>
+<html lang="en">
+  <head>
+    <meta charset="UTF-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <title>LLM Fill in the Blank</title>
+    <link
+      rel="icon"
+      type="image/svg+xml"
+      href="data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 16 16'%3E%3Cpath fill='%230d6efd' d='M14 2H2v12h12V2zM3 3h10v10H3V3z'/%3E%3C/svg%3E"
+    />
+    <link
+      href="https://cdn.jsdelivr.net/npm/bootstrap@5.3.6/dist/css/bootstrap.min.css"
+      rel="stylesheet"
+    />
+    <link
+      href="https://cdn.jsdelivr.net/npm/bootstrap-icons@1.11.1/font/bootstrap-icons.css"
+      rel="stylesheet"
+    />
+  </head>
+  <body class="bg-light">
+    <div class="container py-4">
+      <h1 class="mb-3">
+        <i class="bi bi-pencil-square"></i> LLM Fill in the Blank
+      </h1>
+      <p>
+        Inspired by
+        <a href="https://pair.withgoogle.com/explorables/fill-in-the-blank/"
+          >Google's Fill in the Blank</a
+        >, type a sentence, blank a word and see how an LLM fills it in.
+      </p>
+      <form id="llm-form">
+        <textarea id="sentence-input" class="form-control mb-3" rows="2">
+The quick brown fox jumps over the lazy dog.</textarea
+        >
+        <div id="tokens-container" class="mb-3"></div>
+        <div id="loading" class="mb-2 d-none">
+          <span class="spinner-border spinner-border-sm"></span> Loading...
+        </div>
+        <div id="logprobs-container" class="d-flex flex-wrap"></div>
+        <div class="accordion mt-4" id="settings">
+          <div class="accordion-item">
+            <h2 class="accordion-header">
+              <button
+                class="accordion-button collapsed"
+                type="button"
+                data-bs-toggle="collapse"
+                data-bs-target="#api-settings"
+              >
+                API Settings
+              </button>
+            </h2>
+            <div id="api-settings" class="accordion-collapse collapse">
+              <div class="accordion-body">
+                <div class="mb-3">
+                  <label for="api-key" class="form-label">API Key</label>
+                  <input type="password" id="api-key" class="form-control" />
+                </div>
+                <div class="mb-3">
+                  <label for="api-base" class="form-label">Base URL</label>
+                  <input
+                    type="text"
+                    id="api-base"
+                    class="form-control"
+                    value="https://api.openai.com/v1"
+                    list="base-list"
+                  />
+                  <datalist id="base-list">
+                    <option value="https://api.openai.com/v1"></option>
+                    <option
+                      value="https://llmfoundry.straive.com/openai/v1"
+                    ></option>
+                    <option
+                      value="https://llmfoundry.straivedemo.com/openai/v1"
+                    ></option>
+                  </datalist>
+                </div>
+                <div class="mb-3">
+                  <label for="model" class="form-label">Model</label>
+                  <input
+                    type="text"
+                    id="model"
+                    class="form-control"
+                    list="model-list"
+                    value="openai/gpt-4.1-nano"
+                  />
+                  <datalist id="model-list">
+                    <option value="openai/gpt-4.1-nano"></option>
+                    <option value="openai/gpt-4.1-mini"></option>
+                    <option value="openai/gpt-4.1"></option>
+                    <option value="openai/gpt-4o-mini"></option>
+                    <option value="google/gemini-2.0-flash-lite-001"></option>
+                    <option value="google/gemini-2.0-flash-001"></option>
+                    <option
+                      value="google/gemini-2.5-flash-preview-05-20"
+                    ></option>
+                    <option value="google/gemma-2b-it"></option>
+                    <option value="google/gemma-3n-e4b-it:free"></option>
+                    <option value="google/gemma-3-12b-it"></option>
+                    <option value="google/gemma-3-27b-it"></option>
+                    <option value="anthropic/claude-3-haiku"></option>
+                    <option value="anthropic/claude-3.5-haiku"></option>
+                    <option value="anthropic/claude-sonnet-4"></option>
+                    <option
+                      value="meta-llama/llama-3.3-8b-instruct:free"
+                    ></option>
+                    <option value="meta-llama/llama-4-scout"></option>
+                    <option value="meta-llama/llama-4-maverick"></option>
+                    <option value="meta-llama/llama-3.3-70b-instruct"></option>
+                    <option value="meta-llama/llama-3.2-3b-instruct"></option>
+                    <option value="meta-llama/llama-3.2-1b-instruct"></option>
+                    <option value="meta-llama/llama-3.1-405b-instruct"></option>
+                    <option value="meta-llama/llama-3-70b-instruct"></option>
+                    <option value="meta-llama/llama-3-8b-instruct"></option>
+                    <option value="deepseek/deepseek-chat-v3-0324"></option>
+                    <option value="deepseek/deepseek-r1"></option>
+                    <option value="x-ai/grok-3-beta"></option>
+                    <option value="x-ai/grok-3-mini-beta"></option>
+                    <option value="amazon/nova-micro-v1"></option>
+                    <option value="amazon/nova-lite-v1"></option>
+                  </datalist>
+                </div>
+              </div>
+            </div>
+          </div>
+        </div>
+      </form>
+    </div>
+    <script src="https://cdn.jsdelivr.net/npm/bootstrap@5.3.6/dist/js/bootstrap.bundle.min.js"></script>
+    <script type="module" src="script.js"></script>
+  </body>
+</html>

--- a/llmfill/script.js
+++ b/llmfill/script.js
@@ -1,0 +1,134 @@
+import { asyncLLM } from "https://cdn.jsdelivr.net/npm/asyncllm@2";
+import saveform from "https://cdn.jsdelivr.net/npm/saveform@1.2";
+import * as d3 from "https://cdn.jsdelivr.net/npm/d3@7/+esm";
+
+const form = document.getElementById("llm-form");
+const sentenceInput = document.getElementById("sentence-input");
+const tokensContainer = document.getElementById("tokens-container");
+const logprobsContainer = document.getElementById("logprobs-container");
+const loading = document.getElementById("loading");
+
+const apiKeyInput = document.getElementById("api-key");
+const apiBaseInput = document.getElementById("api-base");
+const modelInput = document.getElementById("model");
+
+let tokens = [];
+let saved;
+
+document.addEventListener("DOMContentLoaded", () => {
+  saved = saveform("#llm-form", { exclude: '[type="file"]' });
+  updateTokens();
+});
+
+function split(text) {
+  return text.match(/[\w']+|[^\w\s]+/g) || [];
+}
+
+function renderTokens() {
+  tokensContainer.innerHTML = tokens
+    .map(
+      (t, i) => `
+      <button type="button" class="btn btn-sm ${t.blank ? "btn-primary" : "btn-outline-secondary"} m-1" data-idx="${i}">
+        ${t.blank ? "_______" : t.text}
+      </button>`,
+    )
+    .join(" ");
+}
+
+function updateTokens() {
+  tokens = split(sentenceInput.value).map((t) => ({ text: t, blank: false }));
+  renderTokens();
+  logprobsContainer.innerHTML = "";
+}
+
+sentenceInput.addEventListener("input", updateTokens);
+
+tokensContainer.addEventListener("click", (e) => {
+  const idx = e.target.dataset.idx;
+  if (idx === undefined) return;
+  tokens[idx].blank = !tokens[idx].blank;
+  renderTokens();
+  logprobsContainer.innerHTML = "";
+  if (tokens[idx].blank) fillBlank(idx);
+});
+
+function modelName() {
+  const base = apiBaseInput.value.trim();
+  let m = modelInput.value.trim();
+  if (m.startsWith("openai/") && base.includes("api.openai.com"))
+    m = m.replace("openai/", "");
+  return m;
+}
+
+async function fillBlank(idx) {
+  const apiKey = apiKeyInput.value.trim();
+  const baseUrl = apiBaseInput.value.trim().replace(/\/$/, "");
+  if (!apiKey || !baseUrl) return;
+
+  const prompt = tokens.map((t, i) => (i === idx ? "_____" : t.text)).join(" ");
+
+  loading.classList.remove("d-none");
+  const filled = [];
+  const probs = [];
+
+  try {
+    for await (const chunk of asyncLLM(`${baseUrl}/chat/completions`, {
+      method: "POST",
+      headers: {
+        "Content-Type": "application/json",
+        Authorization: `Bearer ${apiKey}`,
+      },
+      body: JSON.stringify({
+        model: modelName(),
+        stream: true,
+        max_tokens: 5,
+        logprobs: true,
+        top_logprobs: 20,
+        messages: [
+          {
+            role: "system",
+            content:
+              "Fill in the blank in the sentence. Reply with only the missing text.",
+          },
+          { role: "user", content: prompt },
+        ],
+      }),
+    })) {
+      const choice = chunk.choices?.[0];
+      if (!choice) continue;
+      const delta = choice.delta?.content;
+      const lp = choice.logprobs?.content?.[0];
+      if (delta) filled.push(delta);
+      if (lp) probs.push(lp);
+    }
+    tokens[idx] = { text: filled.join("").trim(), blank: false };
+    renderTokens();
+    renderLogprobs(probs);
+  } catch (e) {
+    logprobsContainer.innerHTML = `<div class="alert alert-danger">${e.message}</div>`;
+  } finally {
+    loading.classList.add("d-none");
+  }
+}
+
+function renderLogprobs(probs) {
+  logprobsContainer.innerHTML = "";
+  if (!probs.length) return;
+  const color = d3.scaleSequential(d3.interpolateReds).domain([-20, 0]);
+  probs.forEach((p) => {
+    const rows = p.top_logprobs
+      .map((tp) => {
+        const prob = Math.exp(tp.logprob);
+        const display =
+          prob > 0.001 ? `${(prob * 100).toFixed(1)}%` : prob.toExponential(2);
+        const bg = color(Math.max(-20, Math.min(0, tp.logprob)));
+        const style = `background:${bg};color:${tp.logprob < -10 ? "#fff" : "#000"}`;
+        return `<tr><td>${tp.token}</td><td style="${style}">${display}</td></tr>`;
+      })
+      .join("");
+    logprobsContainer.insertAdjacentHTML(
+      "beforeend",
+      `<table class="table table-bordered me-2 mb-2 small w-auto"><thead><tr><th colspan="2" class="text-center">${p.token}</th></tr></thead><tbody>${rows}</tbody></table>`,
+    );
+  });
+}

--- a/tools.json
+++ b/tools.json
@@ -22,6 +22,13 @@
       "created": "2025-05-11T16:15:54+05:30"
     },
     {
+      "icon": "bi-pencil-square",
+      "title": "LLM Fill-in-the-Blank",
+      "description": "Blank any word in a sentence and see what an LLM predicts",
+      "url": "llmfill",
+      "created": "2025-06-09T00:00:00+08:00"
+    },
+    {
       "icon": "bi-mic",
       "title": "Podcast Generator",
       "description": "Generate podcasts from text using LLMs",


### PR DESCRIPTION
## Summary
- add new llmfill tool for exploring model fill-ins with logprobs
- list llmfill as the 4th tool in tools.json

## Testing
- `npm test` *(fails: vitest not found)*

------
https://chatgpt.com/codex/tasks/task_e_68467783c958832cb789dd326fa13df6