### PR TITLE
Add Google Tasks exporter

### DIFF
--- a/common/csv.js
+++ b/common/csv.js
@@ -23,14 +23,17 @@ export function objectsToCsv(data, format = csvFormat) {
 
 export const objectsToTsv = (data) => objectsToCsv(data, tsvFormat);
 
-export function csvToTable(element, csv, columns) {
+export function csvToTable(element, csv, columns, rowClassFn) {
   const parsed = csvParse(csv);
   const headers = columns && columns.length ? columns : parsed.columns;
   element.innerHTML = /* html */ `
     <table class="table table-striped table-bordered">
       <thead><tr>${headers.map((h) => `<th>${h}</th>`).join("")}</tr></thead>
       <tbody>${parsed
-        .map((row) => `<tr>${headers.map((h) => `<td>${row[h] || ""}</td>`).join("")}</tr>`)
+        .map((row) => {
+          const cls = rowClassFn ? rowClassFn(row) : "";
+          return `<tr${cls ? ` class="${cls}"` : ""}>${headers.map((h) => `<td>${row[h] || ""}</td>`).join("")}</tr>`;
+        })
         .join("")}</tbody>
     </table>`;
 }

--- a/common/csv.js
+++ b/common/csv.js
@@ -23,9 +23,9 @@ export function objectsToCsv(data, format = csvFormat) {
 
 export const objectsToTsv = (data) => objectsToCsv(data, tsvFormat);
 
-export function csvToTable(element, csv) {
+export function csvToTable(element, csv, columns) {
   const parsed = csvParse(csv);
-  const headers = parsed.columns;
+  const headers = columns && columns.length ? columns : parsed.columns;
   element.innerHTML = /* html */ `
     <table class="table table-striped table-bordered">
       <thead><tr>${headers.map((h) => `<th>${h}</th>`).join("")}</tr></thead>
@@ -39,7 +39,10 @@ export function downloadCsv(csv, filename = "data.csv") {
   const blob = new Blob([csv], { type: "text/csv;charset=utf-8;" });
   if (navigator.msSaveBlob) return navigator.msSaveBlob(blob, filename);
   const url = URL.createObjectURL(blob);
-  Object.assign(document.createElement("a"), { href: url, download: filename }).click();
+  Object.assign(document.createElement("a"), {
+    href: url,
+    download: filename,
+  }).click();
   URL.revokeObjectURL(url);
 }
 

--- a/common/csv.js
+++ b/common/csv.js
@@ -1,0 +1,46 @@
+import { csvFormat, csvParse, tsvFormat } from "https://cdn.jsdelivr.net/npm/d3-dsv@3/+esm";
+
+export function flattenObject(obj, prefix = "") {
+  return Object.entries(obj).reduce((acc, [key, value]) => {
+    const newKey = prefix ? `${prefix}.${key}` : key;
+    if (value && typeof value === "object" && !Array.isArray(value)) Object.assign(acc, flattenObject(value, newKey));
+    else acc[newKey] = value;
+    return acc;
+  }, {});
+}
+
+export function objectsToCsv(data, format = csvFormat) {
+  const headers = [];
+  const rows = data.map((item) => {
+    const flat = flattenObject(item);
+    Object.keys(flat).forEach((k) => {
+      if (!headers.includes(k)) headers.push(k);
+    });
+    return flat;
+  });
+  return format(rows, headers);
+}
+
+export const objectsToTsv = (data) => objectsToCsv(data, tsvFormat);
+
+export function csvToTable(element, csv) {
+  const parsed = csvParse(csv);
+  const headers = parsed.columns;
+  element.innerHTML = /* html */ `
+    <table class="table table-striped table-bordered">
+      <thead><tr>${headers.map((h) => `<th>${h}</th>`).join("")}</tr></thead>
+      <tbody>${parsed
+        .map((row) => `<tr>${headers.map((h) => `<td>${row[h] || ""}</td>`).join("")}</tr>`)
+        .join("")}</tbody>
+    </table>`;
+}
+
+export function downloadCsv(csv, filename = "data.csv") {
+  const blob = new Blob([csv], { type: "text/csv;charset=utf-8;" });
+  if (navigator.msSaveBlob) return navigator.msSaveBlob(blob, filename);
+  const url = URL.createObjectURL(blob);
+  Object.assign(document.createElement("a"), { href: url, download: filename }).click();
+  URL.revokeObjectURL(url);
+}
+
+export const copyText = (text) => navigator.clipboard.writeText(text);

--- a/googletasks/README.md
+++ b/googletasks/README.md
@@ -1,0 +1,13 @@
+# Google Tasks Exporter
+
+This tool lets you sign in with your Google account and download all of your tasks as a CSV file.
+It also lets you copy the results straight into Excel and delete all completed tasks.
+
+## How it works
+
+1. Click **Sign in** and approve access to your Google Tasks.
+2. Click **Fetch Tasks** to list all tasks from every list, including completed ones.
+3. Use **Download CSV** or **Copy to Excel** to export the table.
+4. **Delete Completed** removes all tasks marked as completed.
+
+Your access token is stored locally in your browser using `saveform`.

--- a/googletasks/README.md
+++ b/googletasks/README.md
@@ -1,13 +1,13 @@
 # Google Tasks Exporter
 
 This tool lets you sign in with your Google account and download all of your tasks as a CSV file.
-It also lets you copy the results straight into Excel and delete all completed tasks.
+It also lets you copy the results straight into Excel or Markdown, and delete all completed tasks.
 
 ## How it works
 
 1. Click **Sign in** and approve access to your Google Tasks.
 2. Click **Fetch Tasks** to list all tasks from every list, including completed ones.
-3. Use **Download CSV** or **Copy to Excel** to export the table.
+3. Use **Download CSV**, **Copy to Excel**, or **Copy to Markdown** to export the table.
 4. **Delete Completed** removes all tasks marked as completed.
 
 Your access token is stored locally in your browser using `saveform`.

--- a/googletasks/index.html
+++ b/googletasks/index.html
@@ -35,20 +35,23 @@
             placeholder="Click Sign in to get token"
           />
         </div>
-        <button type="button" id="signinBtn" class="btn btn-primary me-2">
+        <button type="button" id="signinBtn" class="btn btn-primary me-2 mb-2">
           <i class="bi bi-google"></i> Sign in
         </button>
-        <button type="button" id="fetchBtn" class="btn btn-primary me-2">
+        <button type="button" id="fetchBtn" class="btn btn-primary me-2 mb-2">
           Fetch Tasks
         </button>
-        <button type="button" id="deleteBtn" class="btn btn-danger me-2 d-none">
+        <button type="button" id="deleteBtn" class="btn btn-danger me-2 mb-2 d-none">
           Delete Completed
         </button>
-        <button type="button" id="downloadBtn" class="btn btn-success d-none">
+        <button type="button" id="downloadBtn" class="btn btn-success mb-2 d-none">
           <i class="bi bi-download"></i> Download CSV
         </button>
-        <button type="button" id="copyBtn" class="btn btn-warning d-none">
+        <button type="button" id="copyBtn" class="btn btn-warning me-2 mb-2 d-none">
           <i class="bi bi-clipboard"></i> Copy to Excel
+        </button>
+        <button type="button" id="mdBtn" class="btn btn-secondary mb-2 d-none">
+          <i class="bi bi-markdown"></i> Copy to Markdown
         </button>
       </form>
       <div id="status" class="text-muted mb-2"></div>

--- a/googletasks/index.html
+++ b/googletasks/index.html
@@ -28,11 +28,22 @@
       <form id="tasks-form" class="mb-3">
         <div class="mb-3">
           <label for="token" class="form-label">Access Token</label>
-          <input type="password" id="token" class="form-control" placeholder="Click Sign in to get token" />
+          <input
+            type="password"
+            id="token"
+            class="form-control"
+            placeholder="Click Sign in to get token"
+          />
         </div>
-        <button type="button" id="signinBtn" class="btn btn-primary me-2"><i class="bi bi-google"></i> Sign in</button>
-        <button type="button" id="fetchBtn" class="btn btn-primary me-2">Fetch Tasks</button>
-        <button type="button" id="deleteBtn" class="btn btn-danger me-2 d-none">Delete Completed</button>
+        <button type="button" id="signinBtn" class="btn btn-primary me-2">
+          <i class="bi bi-google"></i> Sign in
+        </button>
+        <button type="button" id="fetchBtn" class="btn btn-primary me-2">
+          Fetch Tasks
+        </button>
+        <button type="button" id="deleteBtn" class="btn btn-danger me-2 d-none">
+          Delete Completed
+        </button>
         <button type="button" id="downloadBtn" class="btn btn-success d-none">
           <i class="bi bi-download"></i> Download CSV
         </button>
@@ -40,6 +51,7 @@
           <i class="bi bi-clipboard"></i> Copy to Excel
         </button>
       </form>
+      <div id="status" class="text-muted mb-2"></div>
       <div id="output"></div>
     </div>
     <script

--- a/googletasks/index.html
+++ b/googletasks/index.html
@@ -1,0 +1,51 @@
+<!doctype html>
+<html lang="en">
+  <head>
+    <meta charset="UTF-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <title>Google Tasks Exporter</title>
+    <link
+      rel="icon"
+      type="image/svg+xml"
+      href="data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' width='16' height='16' fill='%230d6efd' class='bi bi-check2-square' viewBox='0 0 16 16'%3E%3Cpath d='M14 1H2a1 1 0 0 0-1 1v12a1 1 0 0 0 1 1h12a1 1 0 0 0 1-1V2a1 1 0 0 0-1-1zM2 0a2 2 0 0 0-2 2v12a2 2 0 0 0 2 2h12a2 2 0 0 0 2-2V2a2 2 0 0 0-2-2H2z'/%3E%3Cpath d='M10.97 4.97a.75.75 0 0 1 1.07 1.05l-3.99 4.99a.75.75 0 0 1-1.08.02L4.324 8.384a.75.75 0 1 1 1.06-1.06l2.094 2.093 3.492-4.447z'/%3E%3C/svg%3E"
+    />
+    <link
+      href="https://cdn.jsdelivr.net/npm/bootstrap@5.3.6/dist/css/bootstrap.min.css"
+      rel="stylesheet"
+      crossorigin="anonymous"
+    />
+    <link
+      href="https://cdn.jsdelivr.net/npm/bootstrap-icons@1.11.0/font/bootstrap-icons.css"
+      rel="stylesheet"
+      crossorigin="anonymous"
+    />
+    <script src="https://accounts.google.com/gsi/client" async defer></script>
+  </head>
+  <body>
+    <div class="container my-5">
+      <h1 class="mb-4">Google Tasks Exporter</h1>
+      <div id="alertContainer"></div>
+      <form id="tasks-form" class="mb-3">
+        <div class="mb-3">
+          <label for="token" class="form-label">Access Token</label>
+          <input type="password" id="token" class="form-control" placeholder="Click Sign in to get token" />
+        </div>
+        <button type="button" id="signinBtn" class="btn btn-primary me-2"><i class="bi bi-google"></i> Sign in</button>
+        <button type="button" id="fetchBtn" class="btn btn-primary me-2">Fetch Tasks</button>
+        <button type="button" id="deleteBtn" class="btn btn-danger me-2 d-none">Delete Completed</button>
+        <button type="button" id="downloadBtn" class="btn btn-success d-none">
+          <i class="bi bi-download"></i> Download CSV
+        </button>
+        <button type="button" id="copyBtn" class="btn btn-warning d-none">
+          <i class="bi bi-clipboard"></i> Copy to Excel
+        </button>
+      </form>
+      <div id="output"></div>
+    </div>
+    <script
+      src="https://cdn.jsdelivr.net/npm/bootstrap@5.3.6/dist/js/bootstrap.bundle.min.js"
+      crossorigin="anonymous"
+    ></script>
+    <script type="module" src="script.js"></script>
+  </body>
+</html>

--- a/googletasks/index.html
+++ b/googletasks/index.html
@@ -1,66 +1,64 @@
 <!doctype html>
 <html lang="en">
-  <head>
-    <meta charset="UTF-8" />
-    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
-    <title>Google Tasks Exporter</title>
-    <link
-      rel="icon"
-      type="image/svg+xml"
-      href="data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' width='16' height='16' fill='%230d6efd' class='bi bi-check2-square' viewBox='0 0 16 16'%3E%3Cpath d='M14 1H2a1 1 0 0 0-1 1v12a1 1 0 0 0 1 1h12a1 1 0 0 0 1-1V2a1 1 0 0 0-1-1zM2 0a2 2 0 0 0-2 2v12a2 2 0 0 0 2 2h12a2 2 0 0 0 2-2V2a2 2 0 0 0-2-2H2z'/%3E%3Cpath d='M10.97 4.97a.75.75 0 0 1 1.07 1.05l-3.99 4.99a.75.75 0 0 1-1.08.02L4.324 8.384a.75.75 0 1 1 1.06-1.06l2.094 2.093 3.492-4.447z'/%3E%3C/svg%3E"
-    />
-    <link
-      href="https://cdn.jsdelivr.net/npm/bootstrap@5.3.6/dist/css/bootstrap.min.css"
-      rel="stylesheet"
-      crossorigin="anonymous"
-    />
-    <link
-      href="https://cdn.jsdelivr.net/npm/bootstrap-icons@1.11.0/font/bootstrap-icons.css"
-      rel="stylesheet"
-      crossorigin="anonymous"
-    />
-    <script src="https://accounts.google.com/gsi/client" async defer></script>
-  </head>
-  <body>
-    <div class="container my-5">
-      <h1 class="mb-4">Google Tasks Exporter</h1>
-      <div id="alertContainer"></div>
-      <form id="tasks-form" class="mb-3">
-        <div class="mb-3">
-          <label for="token" class="form-label">Access Token</label>
-          <input
-            type="password"
-            id="token"
-            class="form-control"
-            placeholder="Click Sign in to get token"
-          />
-        </div>
-        <button type="button" id="signinBtn" class="btn btn-primary me-2 mb-2">
-          <i class="bi bi-google"></i> Sign in
-        </button>
-        <button type="button" id="fetchBtn" class="btn btn-primary me-2 mb-2">
-          Fetch Tasks
-        </button>
-        <button type="button" id="deleteBtn" class="btn btn-danger me-2 mb-2 d-none">
-          Delete Completed
-        </button>
-        <button type="button" id="downloadBtn" class="btn btn-success mb-2 d-none">
-          <i class="bi bi-download"></i> Download CSV
-        </button>
-        <button type="button" id="copyBtn" class="btn btn-warning me-2 mb-2 d-none">
-          <i class="bi bi-clipboard"></i> Copy to Excel
-        </button>
-        <button type="button" id="mdBtn" class="btn btn-secondary mb-2 d-none">
-          <i class="bi bi-markdown"></i> Copy to Markdown
-        </button>
-      </form>
-      <div id="status" class="text-muted mb-2"></div>
-      <div id="output"></div>
-    </div>
-    <script
-      src="https://cdn.jsdelivr.net/npm/bootstrap@5.3.6/dist/js/bootstrap.bundle.min.js"
-      crossorigin="anonymous"
-    ></script>
-    <script type="module" src="script.js"></script>
-  </body>
+
+<head>
+  <meta charset="UTF-8" />
+  <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+  <title>Google Tasks Exporter</title>
+  <link
+    rel="icon"
+    type="image/svg+xml"
+    href="data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' width='16' height='16' fill='%230d6efd' class='bi bi-check2-square' viewBox='0 0 16 16'%3E%3Cpath d='M14 1H2a1 1 0 0 0-1 1v12a1 1 0 0 0 1 1h12a1 1 0 0 0 1-1V2a1 1 0 0 0-1-1zM2 0a2 2 0 0 0-2 2v12a2 2 0 0 0 2 2h12a2 2 0 0 0 2-2V2a2 2 0 0 0-2-2H2z'/%3E%3Cpath d='M10.97 4.97a.75.75 0 0 1 1.07 1.05l-3.99 4.99a.75.75 0 0 1-1.08.02L4.324 8.384a.75.75 0 1 1 1.06-1.06l2.094 2.093 3.492-4.447z'/%3E%3C/svg%3E" />
+  <link
+    href="https://cdn.jsdelivr.net/npm/bootstrap@5.3.6/dist/css/bootstrap.min.css"
+    rel="stylesheet"
+    crossorigin="anonymous" />
+  <link
+    href="https://cdn.jsdelivr.net/npm/bootstrap-icons@1.11.0/font/bootstrap-icons.css"
+    rel="stylesheet"
+    crossorigin="anonymous" />
+  <script src="https://accounts.google.com/gsi/client" async defer></script>
+</head>
+
+<body>
+  <div class="container my-5">
+    <h1 class="mb-4">Google Tasks Exporter</h1>
+    <div id="alertContainer"></div>
+    <form id="googletasks-form" class="mb-3">
+      <div class="mb-3">
+        <label for="token" class="form-label">Access Token</label>
+        <input
+          type="password"
+          id="token"
+          class="form-control"
+          placeholder="Click Sign in to get token" />
+      </div>
+      <button type="button" id="signinBtn" class="btn btn-primary me-2 mb-2">
+        <i class="bi bi-google"></i> Sign in
+      </button>
+      <button type="button" id="fetchBtn" class="btn btn-primary me-2 mb-2">
+        Fetch Tasks
+      </button>
+      <button type="button" id="deleteBtn" class="btn btn-danger me-2 mb-2 d-none">
+        Delete Completed
+      </button>
+      <button type="button" id="downloadBtn" class="btn btn-success mb-2 d-none">
+        <i class="bi bi-download"></i> Download CSV
+      </button>
+      <button type="button" id="copyBtn" class="btn btn-warning me-2 mb-2 d-none">
+        <i class="bi bi-clipboard"></i> Copy to Excel
+      </button>
+      <button type="button" id="mdBtn" class="btn btn-secondary mb-2 d-none">
+        <i class="bi bi-markdown"></i> Copy to Markdown
+      </button>
+    </form>
+    <div id="status" class="text-muted mb-2"></div>
+  </div>
+  <div class="container-fluid table-responsive" id="output"></div>
+  <script
+    src="https://cdn.jsdelivr.net/npm/bootstrap@5.3.6/dist/js/bootstrap.bundle.min.js"
+    crossorigin="anonymous"></script>
+  <script type="module" src="script.js"></script>
+</body>
+
 </html>

--- a/googletasks/script.js
+++ b/googletasks/script.js
@@ -1,6 +1,8 @@
 import saveform from "https://cdn.jsdelivr.net/npm/saveform@1.2";
 import { objectsToCsv, objectsToTsv, csvToTable, downloadCsv, copyText } from "../common/csv.js";
 
+// root.node@gmail.com | Project: Personal mail etc. OAuth Client: Web apps
+// https://console.cloud.google.com/auth/clients/872568319651-r1jl15a1oektabjl48ch3v9dhipkpdjh.apps.googleusercontent.com?inv=1&invt=AbzTOQ&project=encoded-ensign-221
 const clientId = "872568319651-r1jl15a1oektabjl48ch3v9dhipkpdjh.apps.googleusercontent.com";
 let tokenClient;
 let tasks = [];
@@ -32,7 +34,7 @@ const copyBtn = document.getElementById("copyBtn");
 const deleteBtn = document.getElementById("deleteBtn");
 const mdBtn = document.getElementById("mdBtn");
 
-saveform("#tasks-form");
+saveform("#googletasks-form", { exclude: '[type="file"], [type="button"]' });
 
 function showAlert(message, type = "info", autoClose = false) {
   alerts.insertAdjacentHTML(
@@ -48,7 +50,10 @@ window.onload = () => {
   tokenClient = google.accounts.oauth2.initTokenClient({
     client_id: clientId,
     scope: "https://www.googleapis.com/auth/tasks",
-    callback: (resp) => (tokenInput.value = resp.access_token),
+    callback: (resp) => {
+      tokenInput.value = resp.access_token;
+      tokenInput.dispatchEvent(new Event("change", { bubbles: true }));
+    },
   });
 };
 
@@ -68,7 +73,7 @@ fetchBtn.addEventListener("click", async () => {
       updated: fmtDate(t.updated),
       due: fmtDate(t.due),
     }));
-    const cols = ["list", "title", "notes", "links", "updated", "due", "parent", "id"];
+    const cols = ["list", "title", "notes", "updated", "due", "parent", "id"];
     csvToTable(output, objectsToCsv(display), cols, (r) => (r.status === "completed" ? "text-muted" : ""));
     [downloadBtn, copyBtn, mdBtn, deleteBtn].forEach((b) => b.classList.remove("d-none"));
     status.textContent = `Fetched ${tasks.length} tasks`;

--- a/googletasks/script.js
+++ b/googletasks/script.js
@@ -1,0 +1,119 @@
+import saveform from "https://cdn.jsdelivr.net/npm/saveform@1.2";
+import { objectsToCsv, objectsToTsv, csvToTable, downloadCsv, copyText } from "../common/csv.js";
+
+const clientId = "872568319651-r1jl15a1oektabjl48ch3v9dhipkpdjh.apps.googleusercontent.com";
+let tokenClient;
+let tasks = [];
+
+const alerts = document.getElementById("alertContainer");
+const tokenInput = document.getElementById("token");
+const output = document.getElementById("output");
+const signinBtn = document.getElementById("signinBtn");
+const fetchBtn = document.getElementById("fetchBtn");
+const downloadBtn = document.getElementById("downloadBtn");
+const copyBtn = document.getElementById("copyBtn");
+const deleteBtn = document.getElementById("deleteBtn");
+
+saveform("#tasks-form");
+
+function showAlert(message, type = "info", autoClose = false) {
+  alerts.insertAdjacentHTML(
+    "beforeend",
+    `<div class="alert alert-${type} alert-dismissible fade show">${message}<button type="button" class="btn-close" data-bs-dismiss="alert"></button></div>`,
+  );
+  const alert = alerts.lastElementChild;
+  if (autoClose) setTimeout(() => alert.remove(), 3000);
+  return alert;
+}
+
+window.onload = () => {
+  tokenClient = google.accounts.oauth2.initTokenClient({
+    client_id: clientId,
+    scope: "https://www.googleapis.com/auth/tasks",
+    callback: (resp) => (tokenInput.value = resp.access_token),
+  });
+};
+
+signinBtn.addEventListener("click", () => tokenClient.requestAccessToken());
+
+fetchBtn.addEventListener("click", async () => {
+  output.innerHTML = "";
+  const token = tokenInput.value.trim();
+  if (!token) return showAlert("Please sign in first", "warning", true);
+  try {
+    tasks = await fetchTasks(token);
+    if (!tasks.length) return showAlert("No tasks found", "warning", true);
+    const csv = objectsToCsv(tasks);
+    csvToTable(output, csv);
+    downloadBtn.classList.remove("d-none");
+    copyBtn.classList.remove("d-none");
+    deleteBtn.classList.remove("d-none");
+  } catch (e) {
+    showAlert(e.message, "danger");
+  }
+});
+
+downloadBtn.addEventListener("click", () => downloadCsv(objectsToCsv(tasks), "tasks.csv"));
+
+copyBtn.addEventListener("click", async () => {
+  await copyText(objectsToTsv(tasks));
+  showAlert("Copied to clipboard", "success", true);
+});
+
+deleteBtn.addEventListener("click", async () => {
+  const token = tokenInput.value.trim();
+  if (!token) return showAlert("Please sign in first", "warning", true);
+  try {
+    await deleteCompleted(token);
+    showAlert("Completed tasks deleted", "success", true);
+  } catch (e) {
+    showAlert(e.message, "danger");
+  }
+});
+
+async function fetchTasks(token) {
+  const headers = { Authorization: `Bearer ${token}` };
+  const listRes = await fetch("https://tasks.googleapis.com/tasks/v1/users/@me/lists", { headers });
+  if (!listRes.ok) throw new Error("Failed to fetch task lists");
+  const lists = (await listRes.json()).items || [];
+  const all = [];
+  for (const list of lists) {
+    let pageToken;
+    do {
+      const url = new URL(`https://tasks.googleapis.com/tasks/v1/lists/${list.id}/tasks`);
+      url.searchParams.set("showCompleted", "true");
+      if (pageToken) url.searchParams.set("pageToken", pageToken);
+      const res = await fetch(url, { headers });
+      if (!res.ok) throw new Error(`Failed to fetch tasks for ${list.title}`);
+      const data = await res.json();
+      (data.items || []).forEach((t) => all.push({ list: list.title, ...t }));
+      pageToken = data.nextPageToken;
+    } while (pageToken);
+  }
+  return all;
+}
+
+async function deleteCompleted(token) {
+  const headers = { Authorization: `Bearer ${token}` };
+  const listRes = await fetch("https://tasks.googleapis.com/tasks/v1/users/@me/lists", { headers });
+  const lists = (await listRes.json()).items || [];
+  for (const list of lists) {
+    let pageToken;
+    do {
+      const url = new URL(`https://tasks.googleapis.com/tasks/v1/lists/${list.id}/tasks`);
+      url.searchParams.set("showCompleted", "true");
+      if (pageToken) url.searchParams.set("pageToken", pageToken);
+      const res = await fetch(url, { headers });
+      const data = await res.json();
+      for (const task of data.items || []) {
+        if (task.status === "completed") {
+          await fetch(`https://tasks.googleapis.com/tasks/v1/lists/${list.id}/tasks/${task.id}`, {
+            method: "DELETE",
+            headers,
+          });
+        }
+      }
+      pageToken = data.nextPageToken;
+    } while (pageToken);
+  }
+}

--- a/tools.json
+++ b/tools.json
@@ -192,6 +192,12 @@
       "description": "Evaluate quotes from different models and see which one wins",
       "url": "quotesarena",
       "created": "2025-03-30T09:18:58+08:00"
+    },
+    {
+      "icon": "bi-check2-square",
+      "title": "Google Tasks",
+      "description": "Download your Google Tasks as CSV and delete completed tasks",
+      "url": "googletasks"
     }
   ]
 }


### PR DESCRIPTION
## Summary
- add reusable CSV utility functions
- refactor JSON to CSV converter to use shared code
- add Google Tasks exporter tool
- list the new tool in the catalogue

## Testing
- `npm run lint`
- `npm test` *(fails: vitest not found)*

------
https://chatgpt.com/codex/tasks/task_e_6847c0f91700832c945b897d54f186a0