### PR TITLE
Add Markdown table to CSV tool

### DIFF
--- a/md2csv/README.md
+++ b/md2csv/README.md
@@ -1,12 +1,12 @@
 # Markdown Table to CSV
 
-Extract the first table from Markdown and convert it to CSV. Links become their text and images become their alt text.
+Extract the first table from Markdown and convert it to CSV. Links become their text and images are removed.
 
 ## What it does
 
 - Paste Markdown text containing a table
 - Click **Extract Table** to parse the first table using `marked`
-- Links and images are reduced to plain text
+- Links are reduced to plain text and images removed
 - The table is shown on screen
 - Data can be **Download CSV** or **Copy to Excel** (TSV)
 
@@ -18,6 +18,6 @@ Extract the first table from Markdown and convert it to CSV. Links become their 
 ## How It Works
 
 1. `marked` locates the first table token and provides cell tokens
-2. Cell tokens are flattened to plain text, dropping URLs
+2. Cell tokens are flattened to plain text, dropping URLs and images
 3. The data is converted to CSV with utilities in `common/csv.js`
 4. The table preview also relies on these shared helpers

--- a/md2csv/README.md
+++ b/md2csv/README.md
@@ -1,0 +1,23 @@
+# Markdown Table to CSV
+
+Extract the first table from Markdown and convert it to CSV. Links become their text and images become their alt text.
+
+## What it does
+
+- Paste Markdown text containing a table
+- Click **Extract Table** to parse the first table using `marked`
+- Links and images are reduced to plain text
+- The table is shown on screen
+- Data can be **Download CSV** or **Copy to Excel** (TSV)
+
+## Use Cases
+
+- Reuse tables from READMEs or documents in spreadsheets
+- Quickly clean up Markdown tables for data analysis
+
+## How It Works
+
+1. `marked` locates the first table token and provides cell tokens
+2. Cell tokens are flattened to plain text, dropping URLs
+3. The data is converted to CSV with utilities in `common/csv.js`
+4. The table preview also relies on these shared helpers

--- a/md2csv/index.html
+++ b/md2csv/index.html
@@ -1,34 +1,41 @@
 <!doctype html>
 <html lang="en">
-  <head>
-    <meta charset="UTF-8" />
-    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
-    <title>Markdown Table to CSV</title>
-    <link href="https://cdn.jsdelivr.net/npm/bootstrap@5.3.6/dist/css/bootstrap.min.css" rel="stylesheet" crossorigin="anonymous" />
-    <link href="https://cdn.jsdelivr.net/npm/bootstrap-icons@1.11.0/font/bootstrap-icons.css" rel="stylesheet" crossorigin="anonymous" />
-  </head>
-  <body>
-    <div class="container my-5">
-      <h1 class="text-center mb-4">Markdown Table to CSV</h1>
-      <textarea id="markdownInput" class="form-control font-monospace mb-3" rows="8" placeholder="Paste Markdown with a table..."></textarea>
-      <button id="extractBtn" class="btn btn-primary">
-        <i class="bi bi-table"></i> Extract Table
-      </button>
-      <button id="downloadBtn" class="btn btn-success d-none">
-        <i class="bi bi-download"></i> Download CSV
-      </button>
-      <button id="copyBtn" class="btn btn-warning d-none">
-        <i class="bi bi-clipboard"></i> Copy to Excel
-      </button>
-      <div id="output" class="mt-4"></div>
+
+<head>
+  <meta charset="UTF-8" />
+  <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+  <title>Markdown Table to CSV</title>
+  <link
+    rel="icon"
+    type="image/svg+xml"
+    href="data:image/svg+xml;base64,PHN2ZyB4bWxucz0iaHR0cDovL3d3dy53My5vcmcvMjAwMC9zdmciIHZpZXdCb3g9IjAgMCAzMiAzMiI+PGNpcmNsZSBjeD0iMTYiIGN5PSIxNiIgcj0iMTUiIGZpbGw9IiMyNTYzZWIiLz48cGF0aCBmaWxsPSIjZmZmIiBkPSJtMTYgNyAyIDcgNyAyLTcgMi0yIDctMi03LTctMiA3LTJaIi8+PC9zdmc+" />
+  <link href="https://cdn.jsdelivr.net/npm/bootstrap@5.3.6/dist/css/bootstrap.min.css" rel="stylesheet" crossorigin="anonymous" />
+  <link href="https://cdn.jsdelivr.net/npm/bootstrap-icons@1.11.0/font/bootstrap-icons.css" rel="stylesheet" crossorigin="anonymous" />
+</head>
+
+<body>
+  <div class="container my-5">
+    <h1 class="text-center mb-4">Markdown Table to CSV</h1>
+    <textarea id="markdownInput" class="form-control font-monospace mb-3" rows="8" placeholder="Paste Markdown with a table..."></textarea>
+    <button id="extractBtn" class="btn btn-primary">
+      <i class="bi bi-table"></i> Extract Table
+    </button>
+    <button id="downloadBtn" class="btn btn-success d-none">
+      <i class="bi bi-download"></i> Download CSV
+    </button>
+    <button id="copyBtn" class="btn btn-warning d-none">
+      <i class="bi bi-clipboard"></i> Copy to Excel
+    </button>
+    <div id="output" class="mt-4 table-responsive"></div>
+  </div>
+  <div id="toast" class="toast align-items-center text-white bg-primary border-0" role="alert" aria-live="assertive" aria-atomic="true" style="position: fixed; bottom: 20px; right: 20px">
+    <div class="d-flex">
+      <div class="toast-body"></div>
+      <button type="button" class="btn-close btn-close-white me-2 m-auto" data-bs-dismiss="toast" aria-label="Close"></button>
     </div>
-    <div id="toast" class="toast align-items-center text-white bg-primary border-0" role="alert" aria-live="assertive" aria-atomic="true" style="position: fixed; bottom: 20px; right: 20px">
-      <div class="d-flex">
-        <div class="toast-body"></div>
-        <button type="button" class="btn-close btn-close-white me-2 m-auto" data-bs-dismiss="toast" aria-label="Close"></button>
-      </div>
-    </div>
-    <script type="module" src="script.js"></script>
-    <script src="https://cdn.jsdelivr.net/npm/bootstrap@5.3.6/dist/js/bootstrap.bundle.min.js" crossorigin="anonymous"></script>
-  </body>
+  </div>
+  <script type="module" src="script.js"></script>
+  <script src="https://cdn.jsdelivr.net/npm/bootstrap@5.3.6/dist/js/bootstrap.bundle.min.js" crossorigin="anonymous"></script>
+</body>
+
 </html>

--- a/md2csv/index.html
+++ b/md2csv/index.html
@@ -1,0 +1,34 @@
+<!doctype html>
+<html lang="en">
+  <head>
+    <meta charset="UTF-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <title>Markdown Table to CSV</title>
+    <link href="https://cdn.jsdelivr.net/npm/bootstrap@5.3.6/dist/css/bootstrap.min.css" rel="stylesheet" crossorigin="anonymous" />
+    <link href="https://cdn.jsdelivr.net/npm/bootstrap-icons@1.11.0/font/bootstrap-icons.css" rel="stylesheet" crossorigin="anonymous" />
+  </head>
+  <body>
+    <div class="container my-5">
+      <h1 class="text-center mb-4">Markdown Table to CSV</h1>
+      <textarea id="markdownInput" class="form-control font-monospace mb-3" rows="8" placeholder="Paste Markdown with a table..."></textarea>
+      <button id="extractBtn" class="btn btn-primary">
+        <i class="bi bi-table"></i> Extract Table
+      </button>
+      <button id="downloadBtn" class="btn btn-success d-none">
+        <i class="bi bi-download"></i> Download CSV
+      </button>
+      <button id="copyBtn" class="btn btn-warning d-none">
+        <i class="bi bi-clipboard"></i> Copy to Excel
+      </button>
+      <div id="output" class="mt-4"></div>
+    </div>
+    <div id="toast" class="toast align-items-center text-white bg-primary border-0" role="alert" aria-live="assertive" aria-atomic="true" style="position: fixed; bottom: 20px; right: 20px">
+      <div class="d-flex">
+        <div class="toast-body"></div>
+        <button type="button" class="btn-close btn-close-white me-2 m-auto" data-bs-dismiss="toast" aria-label="Close"></button>
+      </div>
+    </div>
+    <script type="module" src="script.js"></script>
+    <script src="https://cdn.jsdelivr.net/npm/bootstrap@5.3.6/dist/js/bootstrap.bundle.min.js" crossorigin="anonymous"></script>
+  </body>
+</html>

--- a/md2csv/script.js
+++ b/md2csv/script.js
@@ -11,14 +11,16 @@ const toast = new bootstrap.Toast(document.getElementById("toast"));
 let data = [];
 let csv = "";
 
-const plain = (tokens = []) =>
-  tokens
+const plain = (tokens = []) => {
+  return tokens
     .map((t) => {
       if (t.type === "link") return plain(t.tokens);
       if (t.type === "image") return "";
+      if (t.type === "html" && t.text == "<br>") return "";
       return t.tokens ? plain(t.tokens) : t.text || "";
     })
     .join("");
+};
 
 function parseTable(md) {
   const table = marked.lexer(md).find((t) => t.type === "table");

--- a/md2csv/script.js
+++ b/md2csv/script.js
@@ -1,0 +1,57 @@
+import { objectsToCsv, objectsToTsv, csvToTable, downloadCsv, copyText } from "../common/csv.js";
+import { marked } from "https://cdn.jsdelivr.net/npm/marked/+esm";
+
+const input = document.getElementById("markdownInput");
+const extractBtn = document.getElementById("extractBtn");
+const output = document.getElementById("output");
+const downloadBtn = document.getElementById("downloadBtn");
+const copyBtn = document.getElementById("copyBtn");
+const toast = new bootstrap.Toast(document.getElementById("toast"));
+
+let data = [];
+let csv = "";
+
+const plain = (tokens = []) =>
+  tokens
+    .map((t) => {
+      if (t.type === "link") return plain(t.tokens);
+      if (t.type === "image") return t.text;
+      return t.tokens ? plain(t.tokens) : t.text || "";
+    })
+    .join("");
+
+function parseTable(md) {
+  const table = marked.lexer(md).find((t) => t.type === "table");
+  if (!table) throw new Error("No table found");
+  const headers = table.header.map((c) => plain(c.tokens));
+  return table.rows.map((row) => Object.fromEntries(headers.map((h, i) => [h, plain(row[i].tokens)])));
+}
+
+function showToast(msg) {
+  document.querySelector("#toast .toast-body").textContent = msg;
+  toast.show();
+}
+
+function showError(msg) {
+  output.innerHTML = `<div class="alert alert-danger"><i class="bi bi-exclamation-triangle me-2"></i>${msg}</div>`;
+  downloadBtn.classList.add("d-none");
+  copyBtn.classList.add("d-none");
+}
+
+extractBtn.addEventListener("click", () => {
+  try {
+    data = parseTable(input.value.trim());
+    csv = objectsToCsv(data);
+    csvToTable(output, csv);
+    downloadBtn.classList.remove("d-none");
+    copyBtn.classList.remove("d-none");
+  } catch (e) {
+    showError(e.message);
+  }
+});
+
+downloadBtn.addEventListener("click", () => downloadCsv(csv));
+copyBtn.addEventListener("click", async () => {
+  await copyText(objectsToTsv(data));
+  showToast("Copied to clipboard");
+});

--- a/md2csv/script.js
+++ b/md2csv/script.js
@@ -15,7 +15,7 @@ const plain = (tokens = []) =>
   tokens
     .map((t) => {
       if (t.type === "link") return plain(t.tokens);
-      if (t.type === "image") return t.text;
+      if (t.type === "image") return "";
       return t.tokens ? plain(t.tokens) : t.text || "";
     })
     .join("");

--- a/tools.json
+++ b/tools.json
@@ -198,6 +198,13 @@
       "title": "Google Tasks",
       "description": "Download your Google Tasks as CSV and delete completed tasks",
       "url": "googletasks"
+    },
+    {
+      "icon": "bi-table",
+      "title": "Markdown to CSV",
+      "description": "Extract the first Markdown table and download it as CSV",
+      "url": "md2csv",
+      "created": "2025-06-10T09:30:00+00:00"
     }
   ]
 }


### PR DESCRIPTION
## Summary
- add md2csv tool for extracting Markdown tables
- implement parser that drops link and image URLs
- show results as table with CSV download or Excel copy
- list tool in tools.json

## Testing
- `npm run lint`
- `npm test` *(fails: ENETUNREACH)*

------
https://chatgpt.com/codex/tasks/task_e_6847f9acfec8832c8a03efcbaee26e5e