### PR TITLE
Add CSV joiner tool

### DIFF
--- a/joincsv/index.html
+++ b/joincsv/index.html
@@ -1,0 +1,44 @@
+<!doctype html>
+<html lang="en">
+  <head>
+    <meta charset="UTF-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <title>Join CSV Tables</title>
+    <link
+      href="https://cdn.jsdelivr.net/npm/bootstrap@5.3.6/dist/css/bootstrap.min.css"
+      rel="stylesheet"
+      crossorigin="anonymous"
+    />
+    <link
+      href="https://cdn.jsdelivr.net/npm/bootstrap-icons@1.11.0/font/bootstrap-icons.css"
+      rel="stylesheet"
+      crossorigin="anonymous"
+    />
+  </head>
+  <body>
+    <div class="container my-5">
+      <h1 class="text-center mb-4">Join CSV Tables</h1>
+      <div class="mb-3">
+        <label for="separator" class="form-label">Separator</label>
+        <input id="separator" list="sep-list" class="form-control" value="," />
+        <datalist id="sep-list">
+          <option value="," label="Comma"></option>
+          <option value="tab" label="Tab"></option>
+          <option value="|" label="Pipe"></option>
+          <option value=" " label="Space"></option>
+          <option value=";" label="Semicolon"></option>
+        </datalist>
+      </div>
+      <textarea id="tables" class="form-control font-monospace mb-3" rows="8"></textarea>
+      <button id="joinBtn" class="btn btn-primary mb-3"><i class="bi bi-arrow-left-right"></i> Join</button>
+      <button id="downloadBtn" class="btn btn-success mb-3 d-none"><i class="bi bi-download"></i> Download CSV</button>
+      <button id="copyBtn" class="btn btn-warning mb-3 d-none"><i class="bi bi-clipboard"></i> Copy to Excel</button>
+      <textarea id="output" class="form-control font-monospace" rows="8" readonly></textarea>
+      <p class="mt-3 text-muted">
+        Paste multiple tables above separated by two blank lines, choose a separator and click Join. Missing values will
+        be blank.
+      </p>
+    </div>
+    <script type="module" src="script.js"></script>
+  </body>
+</html>

--- a/joincsv/script.js
+++ b/joincsv/script.js
@@ -1,0 +1,67 @@
+import { csvFormat, tsvFormat, dsvFormat } from "https://cdn.jsdelivr.net/npm/d3-dsv@3/+esm";
+import { downloadCsv, copyText } from "../common/csv.js";
+
+const separatorInput = document.getElementById("separator");
+const tablesInput = document.getElementById("tables");
+const joinBtn = document.getElementById("joinBtn");
+const downloadBtn = document.getElementById("downloadBtn");
+const copyBtn = document.getElementById("copyBtn");
+const outputArea = document.getElementById("output");
+
+let joined = null;
+
+const getSep = () => (separatorInput.value === "tab" ? "\t" : separatorInput.value || ",");
+
+function parseTables(text, sep) {
+  const chunks = text.trim().split(/\n\s*\n\s*/);
+  const parser = dsvFormat(sep);
+  return chunks.map((t) => parser.parseRows(t).map((r) => r.map((c) => c.trim())));
+}
+
+function joinTables(tables) {
+  const headers = new Set();
+  const data = new Map();
+  const keyHeader = tables[0][0][0];
+
+  tables.forEach((rows, idx) => {
+    const header = rows[0];
+    for (let c = 1; c < header.length; c++) {
+      let col = header[c];
+      if (headers.has(col)) col = `${col}_${idx + 1}`;
+      headers.add(col);
+      header[c] = col;
+    }
+    for (let r = 1; r < rows.length; r++) {
+      const row = rows[r];
+      const key = row[0];
+      if (!data.has(key)) data.set(key, { [keyHeader]: key });
+      const obj = data.get(key);
+      for (let c = 1; c < header.length; c++) obj[header[c]] = row[c] || "";
+    }
+  });
+
+  const cols = [keyHeader, ...headers];
+  return { rows: Array.from(data.values()), headers: cols };
+}
+
+joinBtn.addEventListener("click", () => {
+  const text = tablesInput.value.trim();
+  if (!text) return;
+  const sep = getSep();
+  const tables = parseTables(text, sep);
+  joined = joinTables(tables);
+  outputArea.value = csvFormat(joined.rows, joined.headers);
+  downloadBtn.classList.remove("d-none");
+  copyBtn.classList.remove("d-none");
+});
+
+downloadBtn.addEventListener("click", () => {
+  if (joined) downloadCsv(csvFormat(joined.rows, joined.headers), "joined.csv");
+});
+
+copyBtn.addEventListener("click", async () => {
+  if (joined) await copyText(tsvFormat(joined.rows, joined.headers));
+});
+
+// Default example
+tablesInput.value = `Name,Age\nAlice,30\nBob,25\n\n\nName,Score\nAlice,85\nCharlie,92`;

--- a/tools.json
+++ b/tools.json
@@ -84,6 +84,13 @@
       "created": "2024-12-11T11:16:08+05:30"
     },
     {
+      "icon": "bi-table",
+      "title": "Join CSV Tables",
+      "description": "Join multiple tables on the first column.",
+      "url": "joincsv",
+      "created": "2025-06-10T09:38:18+00:00"
+    },
+    {
       "icon": "bi-markdown-fill",
       "title": "Render Markdown",
       "description": "Render Markdown to HTML using the GitHub Markdown API.",


### PR DESCRIPTION
## Summary
- add `/joincsv/` tool to merge multiple tables
- wire up datalist separator selection, join button and output
- expose download/copy actions via common utilities
- register tool in `tools.json`

## Testing
- `npx prettier@3.5 --print-width 120 --write joincsv/script.js joincsv/index.html tools.json`
- `npm test` *(fails: ENETUNREACH)*

------
https://chatgpt.com/codex/tasks/task_e_6847fc1b58e0832ca5ed6ee0fe4d1020