### PR TITLE
Standardize toast notifications

### DIFF
--- a/common/toast.js
+++ b/common/toast.js
@@ -1,0 +1,49 @@
+export let toasts = [];
+let container;
+
+function getContainer() {
+  if (container) return container;
+  container = document.createElement("div");
+  container.className = "toast-container position-fixed bottom-0 end-0 p-3";
+  document.body.appendChild(container);
+  return container;
+}
+
+function build({ title = "", body = "", color = "bg-primary" }) {
+  const html = `\n    <div class="toast" role="alert" aria-live="assertive" aria-atomic="true">\n      <div class="toast-header ${color} text-white">\n        <strong class="me-auto">${title}</strong>\n        <button type="button" class="btn-close btn-close-white" data-bs-dismiss="toast"></button>\n      </div>\n      <div class="toast-body">${body}</div>\n    </div>`;
+  const parent = getContainer();
+  parent.insertAdjacentHTML("beforeend", html);
+  const element = parent.lastElementChild;
+  const toast = new bootstrap.Toast(element);
+  element.addEventListener("hidden.bs.toast", () => {
+    toasts = toasts.filter((t) => t.element !== element);
+    element.remove();
+  });
+  toasts.push({ element, toast });
+  return { element, toast };
+}
+
+export function showToast(opts) {
+  build(opts).toast.show();
+}
+
+export function updateLatestToast(opts) {
+  if (!toasts.length) return showToast(opts);
+  const { element, toast } = toasts[toasts.length - 1];
+  if (opts.title) element.querySelector(".me-auto").textContent = opts.title;
+  if (opts.body) element.querySelector(".toast-body").innerHTML = opts.body;
+  if (opts.color) {
+    element.querySelector(".toast-header").className = `toast-header ${opts.color} text-white`;
+  }
+  toast.show();
+}
+
+export function closeLatestToast() {
+  if (!toasts.length) return;
+  const { toast } = toasts[toasts.length - 1];
+  toast.hide();
+}
+
+export function closeAllToasts() {
+  toasts.slice().forEach(({ toast }) => toast.hide());
+}

--- a/excel2jsonl/index.html
+++ b/excel2jsonl/index.html
@@ -49,61 +49,23 @@
         <div class="col-md-6 mb-3">
           <h2><i class="bi bi-input-cursor-text me-2"></i>Input</h2>
           <p>Paste your Excel data here:</p>
-          <textarea
-            id="input"
-            class="form-control"
-            rows="10"
-            placeholder="Paste your Excel data here..."
-          ></textarea>
+          <textarea id="input" class="form-control" rows="10" placeholder="Paste your Excel data here..."></textarea>
         </div>
         <div class="col-md-6 mb-3">
           <h2><i class="bi bi-code me-2"></i>Output (JSONL)</h2>
           <p>Converted JSONL data:</p>
           <div class="textarea-container">
-            <textarea
-              id="output"
-              class="form-control"
-              rows="10"
-              readonly=""
-            ></textarea>
+            <textarea id="output" class="form-control" rows="10" readonly=""></textarea>
             <div class="action-btns">
-              <button
-                id="copyBtn"
-                class="btn btn-primary"
-                title="Copy to clipboard"
-              >
+              <button id="copyBtn" class="btn btn-primary" title="Copy to clipboard">
                 <i class="bi bi-clipboard"></i>
               </button>
-              <button
-                id="downloadBtn"
-                class="btn btn-success"
-                title="Download JSONL"
-                disabled=""
-              >
+              <button id="downloadBtn" class="btn btn-success" title="Download JSONL" disabled="">
                 <i class="bi bi-download"></i>
               </button>
             </div>
           </div>
         </div>
-      </div>
-    </div>
-
-    <div
-      id="toast"
-      class="toast align-items-center text-white bg-primary border-0"
-      role="alert"
-      aria-live="assertive"
-      aria-atomic="true"
-      style="position: fixed; bottom: 20px; right: 20px"
-    >
-      <div class="d-flex">
-        <div class="toast-body"></div>
-        <button
-          type="button"
-          class="btn-close btn-close-white me-2 m-auto"
-          data-bs-dismiss="toast"
-          aria-label="Close"
-        ></button>
       </div>
     </div>
 

--- a/excel2jsonl/script.js
+++ b/excel2jsonl/script.js
@@ -1,16 +1,13 @@
 import * as d3 from "https://cdn.jsdelivr.net/npm/d3@7/+esm";
+import { updateLatestToast } from "../common/toast.js";
 
 const inputTextarea = document.getElementById("input");
 const outputTextarea = document.getElementById("output");
 const copyBtn = document.getElementById("copyBtn");
 const downloadBtn = document.getElementById("downloadBtn");
-const toast = new bootstrap.Toast(document.getElementById("toast"));
 
-function showToast(message, type = "bg-primary") {
-  const toastElement = document.getElementById("toast");
-  toastElement.querySelector(".toast-body").textContent = message;
-  toastElement.className = `toast align-items-center text-white ${type} border-0`;
-  toast.show();
+function showToast(message, color = "bg-primary") {
+  updateLatestToast({ body: message, color });
 }
 
 function convertToJSONL(input) {

--- a/githubstars/script.js
+++ b/githubstars/script.js
@@ -1,5 +1,6 @@
 import { html, render } from "https://cdn.jsdelivr.net/npm/lit-html/+esm";
 import { marked } from "https://cdn.jsdelivr.net/npm/marked/+esm";
+import { showToast } from "../common/toast.js";
 
 const formatters = {
   number: new Intl.NumberFormat("en"),
@@ -100,7 +101,7 @@ document.getElementById("repoForm").addEventListener("submit", async (e) => {
       repoData.filter((repo) => !repo.error),
     );
   } catch (error) {
-    alert(`Error: ${error.message}`);
+    showToast({ title: "Error", body: error.message, color: "bg-danger" });
   } finally {
     loading.classList.add("d-none");
   }

--- a/googlesuggest/script.js
+++ b/googlesuggest/script.js
@@ -1,6 +1,7 @@
 import { html, render } from "https://cdn.jsdelivr.net/npm/lit-html/+esm";
 import { asyncLLM } from "https://cdn.jsdelivr.net/npm/asyncllm@2";
 import { marked } from "https://cdn.jsdelivr.net/npm/marked/+esm";
+import { showToast } from "../common/toast.js";
 
 const COUNTRIES = {
   US: "United States",
@@ -195,7 +196,7 @@ function fetchJsonp(url, timeout = 5000) {
 async function fetchGoogleSuggestions(query) {
   currentQuery = query;
   if (!query.trim()) {
-    alert("Please enter a search term.");
+    showToast({ title: "Error", body: "Please enter a search term.", color: "bg-danger" });
     return null;
   }
 
@@ -329,11 +330,11 @@ async function fetchLLMExplanation(suggestions, query) {
   const apiKey = openaiApiKeyInput.value.trim();
 
   if (!apiKey) {
-    alert("Please enter your OpenAI API Key.");
+    showToast({ title: "Error", body: "Please enter your OpenAI API Key.", color: "bg-danger" });
     return;
   }
   if (!baseUrl) {
-    alert("Please enter the OpenAI Base URL.");
+    showToast({ title: "Error", body: "Please enter the OpenAI Base URL.", color: "bg-danger" });
     return;
   }
 
@@ -411,7 +412,7 @@ explainButton.addEventListener("click", () => {
   if (currentSuggestions && Object.keys(currentSuggestions).length > 0 && currentQuery) {
     fetchLLMExplanation(currentSuggestions, currentQuery);
   } else {
-    alert("Please fetch some suggestions first for a valid query.");
+    showToast({ title: "Error", body: "Please fetch some suggestions first for a valid query.", color: "bg-danger" });
   }
 });
 

--- a/hnlinks/script.js
+++ b/hnlinks/script.js
@@ -1,3 +1,5 @@
+import { showToast } from "../common/toast.js";
+
 document.addEventListener("DOMContentLoaded", () => {
   const sourceUrlSelect = document.getElementById("sourceUrl");
   const scrapeButton = document.getElementById("scrapeButton");
@@ -130,7 +132,7 @@ document.addEventListener("DOMContentLoaded", () => {
     } catch (error) {
       console.error("Error scraping links:", error);
       linksTextArea.value = `Error: ${error.message}`;
-      alert(`An error occurred: ${error.message}`);
+      showToast({ title: "Error", body: error.message, color: "bg-danger" });
     } finally {
       loadingIndicator.classList.add("d-none");
       scrapeButton.disabled = false;
@@ -154,7 +156,11 @@ document.addEventListener("DOMContentLoaded", () => {
         })
         .catch((err) => {
           console.error("Failed to copy links:", err);
-          alert("Failed to copy links to clipboard. See console for details.");
+          showToast({
+            title: "Error",
+            body: "Failed to copy links to clipboard. See console for details.",
+            color: "bg-danger",
+          });
         });
     }
   });

--- a/json2csv/index.html
+++ b/json2csv/index.html
@@ -27,38 +27,13 @@
             rows="5"
             placeholder="Paste your JSON here..."
           ></textarea>
-          <button id="convertBtn" class="btn btn-primary">
-            <i class="bi bi-arrow-down-up"></i> Convert
-          </button>
-          <button id="downloadBtn" class="btn btn-success d-none">
-            <i class="bi bi-download"></i> Download CSV
-          </button>
-          <button id="copyBtn" class="btn btn-warning d-none">
-            <i class="bi bi-clipboard"></i> Copy to Excel
-          </button>
+          <button id="convertBtn" class="btn btn-primary"><i class="bi bi-arrow-down-up"></i> Convert</button>
+          <button id="downloadBtn" class="btn btn-success d-none"><i class="bi bi-download"></i> Download CSV</button>
+          <button id="copyBtn" class="btn btn-warning d-none"><i class="bi bi-clipboard"></i> Copy to Excel</button>
         </div>
       </div>
 
       <div id="output"></div>
-
-      <div
-        id="toast"
-        class="toast align-items-center text-white bg-primary border-0"
-        role="alert"
-        aria-live="assertive"
-        aria-atomic="true"
-        style="position: fixed; bottom: 20px; right: 20px"
-      >
-        <div class="d-flex">
-          <div class="toast-body"></div>
-          <button
-            type="button"
-            class="btn-close btn-close-white me-2 m-auto"
-            data-bs-dismiss="toast"
-            aria-label="Close"
-          ></button>
-        </div>
-      </div>
     </div>
 
     <script

--- a/json2csv/script.js
+++ b/json2csv/script.js
@@ -1,11 +1,11 @@
 import { objectsToCsv, objectsToTsv, csvToTable, downloadCsv, copyText } from "../common/csv.js";
+import { updateLatestToast } from "../common/toast.js";
 
 const $jsonInput = document.getElementById("jsonInput");
 const $convertBtn = document.getElementById("convertBtn");
 const $output = document.getElementById("output");
 const $downloadBtn = document.getElementById("downloadBtn");
 const $copyBtn = document.getElementById("copyBtn");
-const $toast = new bootstrap.Toast(document.getElementById("toast"));
 
 // Initialize with sample data
 $jsonInput.value = JSON.stringify([
@@ -48,11 +48,8 @@ const jsonToCsv = (jsonStringInput, toTsv = false) => {
 
 const displayCsvTable = (csv) => csvToTable($output, csv);
 
-function showToast(message, type = "bg-primary") {
-  const toastElement = document.getElementById("toast");
-  toastElement.querySelector(".toast-body").textContent = message;
-  toastElement.className = `toast align-items-center text-white ${type} border-0`;
-  $toast.show();
+function showToast(message, color = "bg-primary") {
+  updateLatestToast({ body: message, color });
 }
 
 $convertBtn.addEventListener("click", () => {

--- a/llmboundingbox/script.js
+++ b/llmboundingbox/script.js
@@ -1,6 +1,7 @@
 import { gemini } from "https://cdn.jsdelivr.net/npm/asyncllm@1/dist/gemini.js";
 import { anthropic } from "https://cdn.jsdelivr.net/npm/asyncllm@1/dist/anthropic.js";
 import JSZip from "https://cdn.jsdelivr.net/npm/jszip@3/+esm";
+import { showToast } from "../common/toast.js";
 
 const openai = (d) => d;
 
@@ -139,7 +140,7 @@ async function handleImageUpload(file) {
     );
   } catch (error) {
     console.error("Error processing image:", error);
-    alert("Error processing image. Please try again.");
+    showToast({ title: "Error", body: "Error processing image. Please try again.", color: "bg-danger" });
   }
 }
 

--- a/md2csv/index.html
+++ b/md2csv/index.html
@@ -1,41 +1,44 @@
 <!doctype html>
 <html lang="en">
+  <head>
+    <meta charset="UTF-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <title>Markdown Table to CSV</title>
+    <link
+      rel="icon"
+      type="image/svg+xml"
+      href="data:image/svg+xml;base64,PHN2ZyB4bWxucz0iaHR0cDovL3d3dy53My5vcmcvMjAwMC9zdmciIHZpZXdCb3g9IjAgMCAzMiAzMiI+PGNpcmNsZSBjeD0iMTYiIGN5PSIxNiIgcj0iMTUiIGZpbGw9IiMyNTYzZWIiLz48cGF0aCBmaWxsPSIjZmZmIiBkPSJtMTYgNyAyIDcgNyAyLTcgMi0yIDctMi03LTctMiA3LTJaIi8+PC9zdmc+"
+    />
+    <link
+      href="https://cdn.jsdelivr.net/npm/bootstrap@5.3.6/dist/css/bootstrap.min.css"
+      rel="stylesheet"
+      crossorigin="anonymous"
+    />
+    <link
+      href="https://cdn.jsdelivr.net/npm/bootstrap-icons@1.11.0/font/bootstrap-icons.css"
+      rel="stylesheet"
+      crossorigin="anonymous"
+    />
+  </head>
 
-<head>
-  <meta charset="UTF-8" />
-  <meta name="viewport" content="width=device-width, initial-scale=1.0" />
-  <title>Markdown Table to CSV</title>
-  <link
-    rel="icon"
-    type="image/svg+xml"
-    href="data:image/svg+xml;base64,PHN2ZyB4bWxucz0iaHR0cDovL3d3dy53My5vcmcvMjAwMC9zdmciIHZpZXdCb3g9IjAgMCAzMiAzMiI+PGNpcmNsZSBjeD0iMTYiIGN5PSIxNiIgcj0iMTUiIGZpbGw9IiMyNTYzZWIiLz48cGF0aCBmaWxsPSIjZmZmIiBkPSJtMTYgNyAyIDcgNyAyLTcgMi0yIDctMi03LTctMiA3LTJaIi8+PC9zdmc+" />
-  <link href="https://cdn.jsdelivr.net/npm/bootstrap@5.3.6/dist/css/bootstrap.min.css" rel="stylesheet" crossorigin="anonymous" />
-  <link href="https://cdn.jsdelivr.net/npm/bootstrap-icons@1.11.0/font/bootstrap-icons.css" rel="stylesheet" crossorigin="anonymous" />
-</head>
-
-<body>
-  <div class="container my-5">
-    <h1 class="text-center mb-4">Markdown Table to CSV</h1>
-    <textarea id="markdownInput" class="form-control font-monospace mb-3" rows="8" placeholder="Paste Markdown with a table..."></textarea>
-    <button id="extractBtn" class="btn btn-primary">
-      <i class="bi bi-table"></i> Extract Table
-    </button>
-    <button id="downloadBtn" class="btn btn-success d-none">
-      <i class="bi bi-download"></i> Download CSV
-    </button>
-    <button id="copyBtn" class="btn btn-warning d-none">
-      <i class="bi bi-clipboard"></i> Copy to Excel
-    </button>
-    <div id="output" class="mt-4 table-responsive"></div>
-  </div>
-  <div id="toast" class="toast align-items-center text-white bg-primary border-0" role="alert" aria-live="assertive" aria-atomic="true" style="position: fixed; bottom: 20px; right: 20px">
-    <div class="d-flex">
-      <div class="toast-body"></div>
-      <button type="button" class="btn-close btn-close-white me-2 m-auto" data-bs-dismiss="toast" aria-label="Close"></button>
+  <body>
+    <div class="container my-5">
+      <h1 class="text-center mb-4">Markdown Table to CSV</h1>
+      <textarea
+        id="markdownInput"
+        class="form-control font-monospace mb-3"
+        rows="8"
+        placeholder="Paste Markdown with a table..."
+      ></textarea>
+      <button id="extractBtn" class="btn btn-primary"><i class="bi bi-table"></i> Extract Table</button>
+      <button id="downloadBtn" class="btn btn-success d-none"><i class="bi bi-download"></i> Download CSV</button>
+      <button id="copyBtn" class="btn btn-warning d-none"><i class="bi bi-clipboard"></i> Copy to Excel</button>
+      <div id="output" class="mt-4 table-responsive"></div>
     </div>
-  </div>
-  <script type="module" src="script.js"></script>
-  <script src="https://cdn.jsdelivr.net/npm/bootstrap@5.3.6/dist/js/bootstrap.bundle.min.js" crossorigin="anonymous"></script>
-</body>
-
+    <script type="module" src="script.js"></script>
+    <script
+      src="https://cdn.jsdelivr.net/npm/bootstrap@5.3.6/dist/js/bootstrap.bundle.min.js"
+      crossorigin="anonymous"
+    ></script>
+  </body>
 </html>

--- a/md2csv/script.js
+++ b/md2csv/script.js
@@ -1,4 +1,5 @@
 import { objectsToCsv, objectsToTsv, csvToTable, downloadCsv, copyText } from "../common/csv.js";
+import { updateLatestToast } from "../common/toast.js";
 import { marked } from "https://cdn.jsdelivr.net/npm/marked/+esm";
 
 const input = document.getElementById("markdownInput");
@@ -6,7 +7,6 @@ const extractBtn = document.getElementById("extractBtn");
 const output = document.getElementById("output");
 const downloadBtn = document.getElementById("downloadBtn");
 const copyBtn = document.getElementById("copyBtn");
-const toast = new bootstrap.Toast(document.getElementById("toast"));
 
 let data = [];
 let csv = "";
@@ -29,9 +29,8 @@ function parseTable(md) {
   return table.rows.map((row) => Object.fromEntries(headers.map((h, i) => [h, plain(row[i].tokens)])));
 }
 
-function showToast(msg) {
-  document.querySelector("#toast .toast-body").textContent = msg;
-  toast.show();
+function showToast(msg, color = "bg-primary") {
+  updateLatestToast({ body: msg, color });
 }
 
 function showError(msg) {

--- a/page2md/page2md.js
+++ b/page2md/page2md.js
@@ -1,11 +1,7 @@
 import { Readability } from "@mozilla/readability";
 import TurndownService from "turndown";
-import {
-  gfm,
-  strikethrough,
-  tables,
-  taskListItems,
-} from "@joplin/turndown-plugin-gfm";
+import { gfm, strikethrough, tables, taskListItems } from "@joplin/turndown-plugin-gfm";
+import { showToast } from "../common/toast.js";
 
 /**
  * Converts current page or selected text to Markdown and copies to clipboard
@@ -53,7 +49,7 @@ export async function convert() {
     // Copy to clipboard
     try {
       await navigator.clipboard.writeText(markdown);
-      alert("Page converted to Markdown and copied to clipboard!");
+      showToast({ title: "Success", body: "Page converted to Markdown and copied to clipboard!", color: "bg-success" });
     } catch (clipboardError) {
       // Fallback to creating a temporary textarea element
       const textarea = document.createElement("textarea");
@@ -64,11 +60,16 @@ export async function convert() {
       const success = document.execCommand("copy");
       document.body.removeChild(textarea);
 
-      if (success) alert("Page converted to Markdown and copied to clipboard!");
+      if (success)
+        showToast({
+          title: "Success",
+          body: "Page converted to Markdown and copied to clipboard!",
+          color: "bg-success",
+        });
       else throw new Error("Failed to copy to clipboard");
     }
   } catch (error) {
-    alert("Error converting page: " + error.message);
+    showToast({ title: "Error", body: `Error converting page: ${error.message}`, color: "bg-danger" });
     throw error;
   }
 }

--- a/revealjs/script.js
+++ b/revealjs/script.js
@@ -1,4 +1,5 @@
 import { Marked } from "https://cdn.jsdelivr.net/npm/marked@13/+esm";
+import { showToast } from "../common/toast.js";
 const marked = new Marked();
 
 const textarea = document.getElementById("markdown-input");
@@ -59,6 +60,6 @@ generateBtn.addEventListener("click", () => {
     presentationWindow.document.write(presentationHTML);
     presentationWindow.document.close();
   } catch (error) {
-    alert(`Error: ${error.message}`);
+    showToast({ title: "Error", body: error.message, color: "bg-danger" });
   }
 });

--- a/speakmd/script.js
+++ b/speakmd/script.js
@@ -1,3 +1,5 @@
+import { showToast } from "../common/toast.js";
+
 const form = document.getElementById("speakForm");
 const markdownInput = document.getElementById("markdownInput");
 const modelSelect = document.getElementById("modelSelect");
@@ -52,7 +54,7 @@ form.addEventListener("submit", async (e) => {
       htmlOutput.scrollTop = htmlOutput.scrollHeight;
     }
   } catch (err) {
-    alert("Error: " + err.message);
+    showToast({ title: "Error", body: err.message, color: "bg-danger" });
   } finally {
     loading.classList.add("d-none");
   }

--- a/unicode/index.html
+++ b/unicode/index.html
@@ -43,12 +43,7 @@
         <div class="col-md-8 text-center">
           <h1 class="mb-4">Unicode Character Viewer</h1>
           <div class="mb-3">
-            <textarea
-              id="textInput"
-              class="form-control mb-2"
-              rows="3"
-              placeholder="Enter text here..."
-            ></textarea>
+            <textarea id="textInput" class="form-control mb-2" rows="3" placeholder="Enter text here..."></textarea>
             <button id="readText" class="btn btn-primary btn-lg me-2">
               <i class="bi bi-file-text me-2"></i>Read Text
             </button>
@@ -56,37 +51,15 @@
               <i class="bi bi-clipboard me-2"></i>Read Clipboard
             </button>
           </div>
-          <div
-            id="spinner"
-            class="spinner-border text-primary mt-3 d-none"
-            role="status"
-          >
+          <div id="spinner" class="spinner-border text-primary mt-3 d-none" role="status">
             <span class="visually-hidden">Loading...</span>
           </div>
         </div>
       </div>
       <div class="row justify-content-center">
         <div class="col-md-10">
-          <div
-            id="charContainer"
-            class="d-flex flex-wrap justify-content-center"
-          ></div>
+          <div id="charContainer" class="d-flex flex-wrap justify-content-center"></div>
         </div>
-      </div>
-    </div>
-
-    <div class="toast-container position-fixed bottom-0 end-0 p-3">
-      <div id="errorToast" class="toast" role="alert">
-        <div class="toast-header bg-danger text-white">
-          <i class="bi bi-exclamation-circle me-2"></i>
-          <strong class="me-auto">Error</strong>
-          <button
-            type="button"
-            class="btn-close btn-close-white"
-            data-bs-dismiss="toast"
-          ></button>
-        </div>
-        <div class="toast-body"></div>
       </div>
     </div>
 

--- a/unicode/script.js
+++ b/unicode/script.js
@@ -1,13 +1,12 @@
+import { updateLatestToast } from "../common/toast.js";
 const readClipboardBtn = document.getElementById("readClipboard");
 const charContainer = document.getElementById("charContainer");
 const spinner = document.getElementById("spinner");
-const errorToast = new bootstrap.Toast(document.getElementById("errorToast"));
 const readTextBtn = document.getElementById("readText");
 const textInput = document.getElementById("textInput");
 
 function showError(message) {
-  document.querySelector("#errorToast .toast-body").textContent = message;
-  errorToast.show();
+  updateLatestToast({ title: "Error", body: message, color: "bg-danger" });
 }
 
 function getNonAsciiChars(text) {

--- a/whatsapp/script.js
+++ b/whatsapp/script.js
@@ -1,9 +1,11 @@
+import { showToast } from "../common/toast.js";
+
 document.getElementById("sendButton").addEventListener("click", () => {
   const phoneNumber = document.getElementById("phoneNumber").value.trim();
   if (phoneNumber) {
     const whatsappUrl = `https://wa.me/${phoneNumber}`;
     window.open(whatsappUrl, "_blank");
   } else {
-    alert("Please enter a valid phone number.");
+    showToast({ title: "Error", body: "Please enter a valid phone number.", color: "bg-danger" });
   }
 });

--- a/whatsnear/index.html
+++ b/whatsnear/index.html
@@ -1,56 +1,54 @@
 <!doctype html>
 <html lang="en">
+  <head>
+    <meta charset="UTF-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <title>Nearby Attractions</title>
+    <link
+      href="https://cdn.jsdelivr.net/npm/bootstrap@5.3.6/dist/css/bootstrap.min.css"
+      rel="stylesheet"
+      crossorigin="anonymous"
+    />
+    <link
+      href="https://cdn.jsdelivr.net/npm/bootstrap-icons@1.11.0/font/bootstrap-icons.css"
+      rel="stylesheet"
+      crossorigin="anonymous"
+    />
+    <script src="https://cdn.jsdelivr.net/npm/leaflet@1.7.1/dist/leaflet.js" crossorigin="anonymous"></script>
+    <link href="https://cdn.jsdelivr.net/npm/leaflet@1.7.1/dist/leaflet.css" rel="stylesheet" crossorigin="anonymous" />
+    <style>
+      #map {
+        height: 300px;
+      }
 
-<head>
-  <meta charset="UTF-8" />
-  <meta name="viewport" content="width=device-width, initial-scale=1.0" />
-  <title>Nearby Attractions</title>
-  <link href="https://cdn.jsdelivr.net/npm/bootstrap@5.3.6/dist/css/bootstrap.min.css" rel="stylesheet" crossorigin="anonymous" />
-  <link href="https://cdn.jsdelivr.net/npm/bootstrap-icons@1.11.0/font/bootstrap-icons.css" rel="stylesheet" crossorigin="anonymous" />
-  <script src="https://cdn.jsdelivr.net/npm/leaflet@1.7.1/dist/leaflet.js" crossorigin="anonymous"></script>
-  <link href="https://cdn.jsdelivr.net/npm/leaflet@1.7.1/dist/leaflet.css" rel="stylesheet" crossorigin="anonymous" />
-  <style>
-    #map {
-      height: 300px;
-    }
+      .attraction-card {
+        margin-bottom: 1rem;
+      }
+    </style>
+  </head>
 
-    .attraction-card {
-      margin-bottom: 1rem;
-    }
-
-    .toast-container {
-      position: fixed;
-      top: 20px;
-      right: 20px;
-      z-index: 1100;
-    }
-  </style>
-</head>
-
-<body>
-  <nav class="navbar navbar-light bg-light fixed-top">
-    <div class="container-fluid">
-      <span class="navbar-brand mb-0 h1">Nearby Attractions</span>
-      <button id="refreshBtn" class="btn btn-outline-primary">
-        <i class="bi bi-arrow-clockwise"></i> Refresh
-      </button>
-    </div>
-  </nav>
-
-  <div class="container mt-5 pt-3">
-    <div id="map" class="mb-3"></div>
-    <div id="loadingSpinner" class="text-center d-none">
-      <div class="spinner-border text-primary" role="status">
-        <span class="visually-hidden">Loading...</span>
+  <body>
+    <nav class="navbar navbar-light bg-light fixed-top">
+      <div class="container-fluid">
+        <span class="navbar-brand mb-0 h1">Nearby Attractions</span>
+        <button id="refreshBtn" class="btn btn-outline-primary"><i class="bi bi-arrow-clockwise"></i> Refresh</button>
       </div>
+    </nav>
+
+    <div class="container mt-5 pt-3">
+      <div id="map" class="mb-3"></div>
+      <div id="loadingSpinner" class="text-center d-none">
+        <div class="spinner-border text-primary" role="status">
+          <span class="visually-hidden">Loading...</span>
+        </div>
+      </div>
+      <div id="attractionsList"></div>
     </div>
-    <div id="attractionsList"></div>
-  </div>
 
-  <div class="toast-container"></div>
-
-  <script src="https://cdn.jsdelivr.net/npm/bootstrap@5.3.6/dist/js/bootstrap.bundle.min.js" crossorigin="anonymous"></script>
-  <script type="module" src="script.js"></script>
-</body>
-
+    <script
+      src="https://cdn.jsdelivr.net/npm/bootstrap@5.3.6/dist/js/bootstrap.bundle.min.js"
+      crossorigin="anonymous"
+    ></script>
+    <script type="module" src="script.js"></script>
+  </body>
 </html>

--- a/whatsnear/script.js
+++ b/whatsnear/script.js
@@ -1,4 +1,5 @@
 import { Marked } from "https://cdn.jsdelivr.net/npm/marked@13/+esm";
+import { showToast } from "../common/toast.js";
 const marked = new Marked();
 
 let map,
@@ -154,22 +155,7 @@ function showLoading(isLoading) {
 }
 
 function showError(message) {
-  const toastContainer = document.querySelector(".toast-container");
-  const toastElement = document.createElement("div");
-  toastElement.className = "toast";
-  toastElement.setAttribute("role", "alert");
-  toastElement.setAttribute("aria-live", "assertive");
-  toastElement.setAttribute("aria-atomic", "true");
-  toastElement.innerHTML = `
-              <div class="toast-header bg-danger text-white">
-                  <strong class="me-auto">Error</strong>
-                  <button type="button" class="btn-close" data-bs-dismiss="toast" aria-label="Close"></button>
-              </div>
-              <div class="toast-body">${message}</div>
-          `;
-  toastContainer.appendChild(toastElement);
-  const toast = new bootstrap.Toast(toastElement);
-  toast.show();
+  showToast({ title: "Error", body: message, color: "bg-danger" });
 }
 
 document.addEventListener("DOMContentLoaded", () => {


### PR DESCRIPTION
## Summary
- add common toast helper for Bootstrap notifications
- use toast notifications across tools instead of alerts
- remove redundant toast scaffolding from HTML

## Testing
- `uvx ruff check --line-length 100`


------
https://chatgpt.com/codex/tasks/task_e_6848fe92fa88832c9aae952854d37f72