### PR TITLE
Replace simple alerts with toasts

### DIFF
--- a/githubstars/script.js
+++ b/githubstars/script.js
@@ -101,7 +101,7 @@ document.getElementById("repoForm").addEventListener("submit", async (e) => {
       repoData.filter((repo) => !repo.error),
     );
   } catch (error) {
-    showToast({ title: "Error", body: error.message, color: "bg-danger" });
+    showToast({ title: "Fetch error", body: error.message, color: "bg-danger" });
   } finally {
     loading.classList.add("d-none");
   }

--- a/googlesuggest/script.js
+++ b/googlesuggest/script.js
@@ -196,7 +196,7 @@ function fetchJsonp(url, timeout = 5000) {
 async function fetchGoogleSuggestions(query) {
   currentQuery = query;
   if (!query.trim()) {
-    showToast({ title: "Error", body: "Please enter a search term.", color: "bg-danger" });
+    showToast({ title: "Input needed", body: "Please enter a search term.", color: "bg-danger" });
     return null;
   }
 
@@ -330,11 +330,11 @@ async function fetchLLMExplanation(suggestions, query) {
   const apiKey = openaiApiKeyInput.value.trim();
 
   if (!apiKey) {
-    showToast({ title: "Error", body: "Please enter your OpenAI API Key.", color: "bg-danger" });
+    showToast({ title: "Missing key", body: "Please enter your OpenAI API Key.", color: "bg-danger" });
     return;
   }
   if (!baseUrl) {
-    showToast({ title: "Error", body: "Please enter the OpenAI Base URL.", color: "bg-danger" });
+    showToast({ title: "Missing base URL", body: "Please enter the OpenAI Base URL.", color: "bg-danger" });
     return;
   }
 
@@ -412,7 +412,7 @@ explainButton.addEventListener("click", () => {
   if (currentSuggestions && Object.keys(currentSuggestions).length > 0 && currentQuery) {
     fetchLLMExplanation(currentSuggestions, currentQuery);
   } else {
-    showToast({ title: "Error", body: "Please fetch some suggestions first for a valid query.", color: "bg-danger" });
+    showToast({ title: "No suggestions", body: "Please fetch some suggestions first for a valid query.", color: "bg-danger" });
   }
 });
 

--- a/hnlinks/script.js
+++ b/hnlinks/script.js
@@ -132,7 +132,7 @@ document.addEventListener("DOMContentLoaded", () => {
     } catch (error) {
       console.error("Error scraping links:", error);
       linksTextArea.value = `Error: ${error.message}`;
-      showToast({ title: "Error", body: error.message, color: "bg-danger" });
+      showToast({ title: "Scraping error", body: error.message, color: "bg-danger" });
     } finally {
       loadingIndicator.classList.add("d-none");
       scrapeButton.disabled = false;
@@ -157,7 +157,7 @@ document.addEventListener("DOMContentLoaded", () => {
         .catch((err) => {
           console.error("Failed to copy links:", err);
           showToast({
-            title: "Error",
+            title: "Copy error",
             body: "Failed to copy links to clipboard. See console for details.",
             color: "bg-danger",
           });

--- a/json2csv/json2csv.test.js
+++ b/json2csv/json2csv.test.js
@@ -68,9 +68,8 @@ describe("JSON to CSV tests", async () => {
     convertBtn.click();
     await page.waitUntilComplete();
 
-    const alert = output.querySelector(".alert-danger");
-    expect(alert).not.toBeNull();
-    expect(alert.textContent).toContain("Error: Invalid JSON input.");
+    const toast = document.querySelector(".toast-body");
+    expect(toast.textContent).toContain("Error: Invalid JSON input.");
     expect(downloadBtn.classList.contains("d-none")).toBe(true);
     expect(copyBtn.classList.contains("d-none")).toBe(true);
   });
@@ -80,9 +79,8 @@ describe("JSON to CSV tests", async () => {
     convertBtn.click();
     await page.waitUntilComplete();
 
-    const alert = output.querySelector(".alert-danger");
-    expect(alert).not.toBeNull();
-    expect(alert.textContent).toContain("Error: Please enter some JSON data.");
+    const toast = document.querySelector(".toast-body");
+    expect(toast.textContent).toContain("Error: Please enter some JSON data.");
     expect(downloadBtn.classList.contains("d-none")).toBe(true);
     expect(copyBtn.classList.contains("d-none")).toBe(true);
   });
@@ -99,9 +97,8 @@ describe("JSON to CSV tests", async () => {
     expect(clipboardText).toBe("name	value\nCopy Test	123");
 
     // Check for toast message
-    const toastElement = document.getElementById("toast");
-    expect(toastElement.classList.contains("show")).toBe(true);
-    expect(toastElement.querySelector(".toast-body").textContent).toBe("Copied to clipboard!");
+    const toastElement = document.querySelector(".toast-body");
+    expect(toastElement.textContent).toBe("Copied to clipboard!");
   });
 
   // Note: Actual download functionality is hard to test in JSDOM.

--- a/json2csv/script.js
+++ b/json2csv/script.js
@@ -62,7 +62,8 @@ $convertBtn.addEventListener("click", () => {
     $downloadBtn.classList.remove("d-none");
     $copyBtn.classList.remove("d-none");
   } catch (error) {
-    $output.innerHTML = `<div class="alert alert-danger"><i class="bi bi-exclamation-triangle"></i> Error: ${error.message}</div>`;
+    $output.textContent = "";
+    showToast(`Error: ${error.message}`, "bg-danger");
     $downloadBtn.classList.add("d-none");
     $copyBtn.classList.add("d-none");
   }

--- a/llmboundingbox/script.js
+++ b/llmboundingbox/script.js
@@ -140,7 +140,7 @@ async function handleImageUpload(file) {
     );
   } catch (error) {
     console.error("Error processing image:", error);
-    showToast({ title: "Error", body: "Error processing image. Please try again.", color: "bg-danger" });
+    showToast({ title: "Processing error", body: "Error processing image. Please try again.", color: "bg-danger" });
   }
 }
 

--- a/md2csv/script.js
+++ b/md2csv/script.js
@@ -34,7 +34,8 @@ function showToast(msg, color = "bg-primary") {
 }
 
 function showError(msg) {
-  output.innerHTML = `<div class="alert alert-danger"><i class="bi bi-exclamation-triangle me-2"></i>${msg}</div>`;
+  output.textContent = "";
+  showToast(msg, "bg-danger");
   downloadBtn.classList.add("d-none");
   copyBtn.classList.add("d-none");
 }

--- a/page2md/page2md.js
+++ b/page2md/page2md.js
@@ -49,7 +49,7 @@ export async function convert() {
     // Copy to clipboard
     try {
       await navigator.clipboard.writeText(markdown);
-      showToast({ title: "Success", body: "Page converted to Markdown and copied to clipboard!", color: "bg-success" });
+      showToast({ title: "Copied", body: "Page converted to Markdown and copied to clipboard!", color: "bg-success" });
     } catch (clipboardError) {
       // Fallback to creating a temporary textarea element
       const textarea = document.createElement("textarea");
@@ -62,14 +62,14 @@ export async function convert() {
 
       if (success)
         showToast({
-          title: "Success",
+          title: "Copied",
           body: "Page converted to Markdown and copied to clipboard!",
           color: "bg-success",
         });
       else throw new Error("Failed to copy to clipboard");
     }
   } catch (error) {
-    showToast({ title: "Error", body: `Error converting page: ${error.message}`, color: "bg-danger" });
+    showToast({ title: "Conversion error", body: `Error converting page: ${error.message}`, color: "bg-danger" });
     throw error;
   }
 }

--- a/revealjs/script.js
+++ b/revealjs/script.js
@@ -60,6 +60,6 @@ generateBtn.addEventListener("click", () => {
     presentationWindow.document.write(presentationHTML);
     presentationWindow.document.close();
   } catch (error) {
-    showToast({ title: "Error", body: error.message, color: "bg-danger" });
+    showToast({ title: "Conversion error", body: error.message, color: "bg-danger" });
   }
 });

--- a/speakmd/script.js
+++ b/speakmd/script.js
@@ -54,7 +54,7 @@ form.addEventListener("submit", async (e) => {
       htmlOutput.scrollTop = htmlOutput.scrollHeight;
     }
   } catch (err) {
-    showToast({ title: "Error", body: err.message, color: "bg-danger" });
+    showToast({ title: "Processing error", body: err.message, color: "bg-danger" });
   } finally {
     loading.classList.add("d-none");
   }

--- a/transcribe/script.js
+++ b/transcribe/script.js
@@ -1,4 +1,5 @@
 import { html, render } from "https://cdn.jsdelivr.net/npm/lit-html/+esm";
+import { showToast } from "../common/toast.js";
 
 const $transcript = document.querySelector("#transcript");
 const $app = document.querySelector("#app");
@@ -82,5 +83,5 @@ try {
   $app.classList.remove("d-none");
   initTranscription();
 } catch (err) {
-  render(html`<div class="alert alert-danger">Your browser does not support speech recognition.</div>`, $app);
+  showToast({ title: "Unsupported", body: "Your browser does not support speech recognition.", color: "bg-danger" });
 }

--- a/unicode/script.js
+++ b/unicode/script.js
@@ -6,7 +6,7 @@ const readTextBtn = document.getElementById("readText");
 const textInput = document.getElementById("textInput");
 
 function showError(message) {
-  updateLatestToast({ title: "Error", body: message, color: "bg-danger" });
+  updateLatestToast({ title: "Input error", body: message, color: "bg-danger" });
 }
 
 function getNonAsciiChars(text) {

--- a/whatsapp/script.js
+++ b/whatsapp/script.js
@@ -6,6 +6,6 @@ document.getElementById("sendButton").addEventListener("click", () => {
     const whatsappUrl = `https://wa.me/${phoneNumber}`;
     window.open(whatsappUrl, "_blank");
   } else {
-    showToast({ title: "Error", body: "Please enter a valid phone number.", color: "bg-danger" });
+    showToast({ title: "Invalid number", body: "Please enter a valid phone number.", color: "bg-danger" });
   }
 });

--- a/whatsnear/script.js
+++ b/whatsnear/script.js
@@ -155,7 +155,7 @@ function showLoading(isLoading) {
 }
 
 function showError(message) {
-  showToast({ title: "Error", body: message, color: "bg-danger" });
+  showToast({ title: "Location error", body: message, color: "bg-danger" });
 }
 
 document.addEventListener("DOMContentLoaded", () => {


### PR DESCRIPTION
## Summary
- swap inline alert divs for toast notifications where easy to do
- rename toast titles to briefly reflect the problem
- update tests for the toast change

## Testing
- `uvx ruff check --line-length 100 .`
- `npx prettier@3.5 --print-width=120 '**/*.js' '**/*.md'`
- `npm test` *(fails: ENETUNREACH)*

------
https://chatgpt.com/codex/tasks/task_e_68495179fd18832cb3e535ef9eaf2dd4