### PR TITLE
Improve Recall mobile layout

### DIFF
--- a/recall/index.html
+++ b/recall/index.html
@@ -15,19 +15,21 @@
     <header class="pb-3 mb-4 border-bottom">
       <div class="d-flex align-items-center">
         <i class="bi bi-clock-history fs-1 me-3 text-primary"></i>
-        <h1 class="display-5 fw-bold mb-0">Recall</h1>
+        <h1 id="title" class="display-5 fw-bold mb-0 user-select-none" role="button" style="cursor: pointer">
+          Recall
+        </h1>
       </div>
     </header>
-    <div id="content" class="mb-3">
+    <div id="content" class="fs-5 mb-3">
       <div class="text-center">
         <div class="spinner-border" role="status"></div>
       </div>
     </div>
-    <div class="d-flex flex-wrap gap-2">
-      <select id="file-select" class="form-select w-auto"></select>
-      <input id="decay-input" type="number" class="form-control w-auto" min="0" max="1" step="0.01" value="0.02" style="max-width:7rem" />
-      <button id="another-btn" class="btn btn-primary"><i class="bi bi-shuffle"></i> Another</button>
-      <button id="copy-btn" class="btn btn-secondary"><i class="bi bi-clipboard"></i> Copy</button>
+    <div class="d-flex flex-nowrap gap-2 mt-4">
+      <select id="file-select" class="form-select form-select-sm w-auto"></select>
+      <input id="decay-input" type="number" class="form-control form-control-sm w-auto" min="0" max="1" step="0.01" value="0.02" style="max-width: 7rem" />
+      <button id="another-btn" class="btn btn-primary btn-sm"><i class="bi bi-shuffle"></i> Another</button>
+      <button id="copy-btn" class="btn btn-secondary btn-sm"><i class="bi bi-clipboard"></i> Copy</button>
     </div>
   </div>
   <script src="https://cdn.jsdelivr.net/npm/bootstrap@5.3.6/dist/js/bootstrap.bundle.min.js" crossorigin="anonymous"></script>

--- a/recall/script.js
+++ b/recall/script.js
@@ -17,6 +17,7 @@ const fileSelect = document.getElementById("file-select");
 const anotherBtn = document.getElementById("another-btn");
 const copyBtn = document.getElementById("copy-btn");
 const decayInput = document.getElementById("decay-input");
+const title = document.getElementById("title");
 let items = [];
 let current = "";
 
@@ -58,6 +59,7 @@ function pick() {
 fileSelect.onchange = () => load(fileSelect.value);
 decayInput.oninput = pick;
 anotherBtn.onclick = pick;
+title.onclick = pick;
 copyBtn.onclick = async () => {
   await navigator.clipboard.writeText(current);
   updateLatestToast({ body: "Copied", color: "bg-success" });


### PR DESCRIPTION
## Summary
- adjust styles so Recall controls stay on one row
- enlarge Recall content text and add top margin above controls
- make "Recall" title trigger another card pick
- format HTML for consistency

## Testing
- `npm test` *(fails: ENETUNREACH errors)*

------
https://chatgpt.com/codex/tasks/task_e_687b64791d6c832ca57b7b8162853f00