### PR TITLE
Integrate bootstrap-llm-provider

### DIFF
--- a/common/openai.js
+++ b/common/openai.js
@@ -1,8 +1,5 @@
 import { openaiConfig } from "https://cdn.jsdelivr.net/npm/bootstrap-llm-provider@1";
 
-const cfgURL = new URL("../openai.json", import.meta.url);
-const { defaultBaseUrls } = await fetch(cfgURL).then((r) => r.json());
-
-export function loadOpenAI(show = false) {
+export function loadOpenAI(defaultBaseUrls, show = false) {
   return openaiConfig({ defaultBaseUrls, show });
 }

--- a/githubsummary/index.html
+++ b/githubsummary/index.html
@@ -37,8 +37,8 @@
                   analysis period
                 </li>
                 <li>
-                  <strong>GitHub API Token:</strong> Personal access token for
-                  API access (required for higher rate limits)
+                  <strong>GitHub API Token (optional):</strong> Personal access
+                  token for higher rate limits
                 </li>
                 <li>
                   <strong>OpenAI API Key:</strong> Your OpenAI API key for
@@ -81,11 +81,8 @@
                   </div>
                 </div>
                 <div class="col-md-6">
-                  <label for="github-token" class="form-label">GitHub API Token</label>
-                  <input type="password" class="form-control" id="github-token" required />
-                  <div class="invalid-feedback">
-                    Please provide a GitHub API token.
-                  </div>
+                  <label for="github-token" class="form-label">GitHub API Token (optional)</label>
+                  <input type="password" class="form-control" id="github-token" />
                 </div>
               </div>
 

--- a/githubsummary/script.js
+++ b/githubsummary/script.js
@@ -2,6 +2,13 @@ import { asyncLLM } from "https://cdn.jsdelivr.net/npm/asyncllm@2";
 import saveform from "https://cdn.jsdelivr.net/npm/saveform@1.2";
 import { loadOpenAI } from "../common/openai.js";
 
+const DEFAULT_BASE_URLS = [
+  "https://api.openai.com/v1",
+  "https://aipipe.org/api/v1",
+  "https://llmfoundry.straivedemo.com/openai/v1",
+  "https://llmfoundry.straive.com/openai/v1",
+];
+
 // GitHub API field mappings
 const GITHUB_FIELDS = {
   ForkEvent: ["type", "repo.name", "payload.forkee.full_name", "created_at"],
@@ -33,9 +40,9 @@ const CACHE_TTL = 30 * 24 * 60 * 60 * 1000; // 30 days
 let db = null;
 
 const openaiConfigBtn = document.getElementById("openai-config-btn");
-let aiConfig = await loadOpenAI();
+let aiConfig = await loadOpenAI(DEFAULT_BASE_URLS);
 openaiConfigBtn.addEventListener("click", async () => {
-  aiConfig = await loadOpenAI(true);
+  aiConfig = await loadOpenAI(DEFAULT_BASE_URLS, true);
 });
 
 async function initDB() {
@@ -353,10 +360,8 @@ document.getElementById("github-form").addEventListener("submit", async (e) => {
     if (document.getElementById("clear-cache").value) await clearCache();
 
     // Fetch GitHub data
-    const headers = {
-      "Content-Type": "application/json",
-      Authorization: `Bearer ${config.githubToken}`,
-    };
+    const headers = { "Content-Type": "application/json" };
+    if (config.githubToken) headers.Authorization = `Bearer ${config.githubToken}`;
 
     const { activity, repos } = await fetchGitHubActivity(config.username, config.since, config.until, headers);
 

--- a/googlesuggest/index.html
+++ b/googlesuggest/index.html
@@ -183,7 +183,7 @@
           </div>
           <div class="col-lg-5 col-md-8 mb-2 d-flex align-items-end">
             <button id="openai-config-btn" type="button" class="btn btn-outline-secondary btn-sm w-100">
-              Configure OpenAI
+              Configure OpenRouter
             </button>
           </div>
           <div class="col-lg-2 col-md-4 mb-2">

--- a/googlesuggest/script.js
+++ b/googlesuggest/script.js
@@ -5,6 +5,8 @@ import { showToast } from "../common/toast.js";
 import saveform from "https://cdn.jsdelivr.net/npm/saveform@1.2";
 import { loadOpenAI } from "../common/openai.js";
 
+const DEFAULT_BASE_URLS = ["https://openrouter.ai/api/v1", "https://aipipe.org/openrouter/v1"];
+
 const COUNTRIES = {
   US: "United States",
   GB: "United Kingdom",
@@ -37,9 +39,9 @@ const resetPromptButton = document.getElementById("resetPrompt");
 const copyResponseButton = document.getElementById("copyResponse");
 saveform("#googlesuggest-form", { exclude: '[type="file"]' });
 
-let aiConfig = await loadOpenAI();
+let aiConfig = await loadOpenAI(DEFAULT_BASE_URLS);
 openaiConfigBtn.addEventListener("click", async () => {
-  aiConfig = await loadOpenAI(true);
+  aiConfig = await loadOpenAI(DEFAULT_BASE_URLS, true);
 });
 
 // --- Application State ---

--- a/openai.json
+++ b/openai.json
@@ -1,8 +1,0 @@
-{
-  "defaultBaseUrls": [
-    "https://api.openai.com/v1",
-    "https://aipipe.org/api/v1",
-    "http://llmfoundry.straivedemo.com/openai/v1",
-    "http://llmfoundry.straive.com/openai/v1"
-  ]
-}

--- a/podcast/script.js
+++ b/podcast/script.js
@@ -1,5 +1,12 @@
 import saveform from "https://cdn.jsdelivr.net/npm/saveform@1.2";
 import { loadOpenAI } from "../common/openai.js";
+
+const DEFAULT_BASE_URLS = [
+  "https://api.openai.com/v1",
+  "https://aipipe.org/api/v1",
+  "https://llmfoundry.straivedemo.com/openai/v1",
+  "https://llmfoundry.straive.com/openai/v1",
+];
 let savedForm;
 
 document.addEventListener("DOMContentLoaded", async () => {
@@ -27,9 +34,9 @@ document.addEventListener("DOMContentLoaded", async () => {
   const alertContainer = document.getElementById("alertContainer");
   const resetSettingsBtn = document.getElementById("resetSettingsBtn");
 
-  let aiConfig = await loadOpenAI();
+  let aiConfig = await loadOpenAI(DEFAULT_BASE_URLS);
   openaiConfigBtn.addEventListener("click", async () => {
-    aiConfig = await loadOpenAI(true);
+    aiConfig = await loadOpenAI(DEFAULT_BASE_URLS, true);
   });
 
   // Function to show alerts

--- a/speakmd/index.html
+++ b/speakmd/index.html
@@ -57,7 +57,7 @@ For a table with columns Name and Score and a row Bob 5, say "Columns: Name, Sco
         </div>
         <div class="col-md-6 mb-3 d-flex align-items-end">
           <button id="openai-config-btn" type="button" class="btn btn-outline-secondary w-100">
-            Configure OpenAI
+            Configure OpenRouter
           </button>
         </div>
       </div>

--- a/speakmd/script.js
+++ b/speakmd/script.js
@@ -2,6 +2,8 @@ import { showToast } from "../common/toast.js";
 import saveform from "https://cdn.jsdelivr.net/npm/saveform@1.2";
 import { loadOpenAI } from "../common/openai.js";
 
+const DEFAULT_BASE_URLS = ["https://openrouter.ai/api/v1", "https://aipipe.org/openrouter/v1"];
+
 const form = document.getElementById("speakForm");
 const markdownInput = document.getElementById("markdownInput");
 const modelSelect = document.getElementById("modelSelect");
@@ -12,9 +14,9 @@ const copyBtn = document.getElementById("copyBtn");
 saveform("#speakForm", { exclude: '[type="file"]' });
 const readBtn = document.getElementById("readBtn");
 
-let aiConfig = await loadOpenAI();
+let aiConfig = await loadOpenAI(DEFAULT_BASE_URLS);
 openaiConfigBtn.addEventListener("click", async () => {
-  aiConfig = await loadOpenAI(true);
+  aiConfig = await loadOpenAI(DEFAULT_BASE_URLS, true);
 });
 
 let utterance;


### PR DESCRIPTION
## Summary
- add shared OpenAI config helper
- update SpeakMD, GoogleSuggest, GitHubSummary and Podcast to use provider modal
- replace base URL and API key fields with a configuration button

## Testing
- `npm run lint`
- `npm test` *(fails: ENETUNREACH)*

------
https://chatgpt.com/codex/tasks/task_e_6880ba5cdf68832c8cde5e23d9fae6a8