### PR TITLE
Handle subtasks in Google Tasks

### DIFF
--- a/googletasks/README.md
+++ b/googletasks/README.md
@@ -9,5 +9,6 @@ It also lets you copy the results straight into Excel or Markdown, and delete al
 2. Click **Fetch Tasks** to list all tasks from every list, including completed ones.
 3. Use **Download CSV**, **Copy to Excel**, or **Copy to Markdown** to export the table.
 4. **Delete Completed** removes all tasks marked as completed.
+5. Sub-tasks show up as bullet points in the notes of their parent tasks.
 
 Your access token is stored locally in your browser using `saveform`.

--- a/googletasks/README.md
+++ b/googletasks/README.md
@@ -10,5 +10,6 @@ It also lets you copy the results straight into Excel or Markdown, and delete al
 3. Use **Download CSV**, **Copy to Excel**, or **Copy to Markdown** to export the table.
 4. **Delete Completed** removes all tasks marked as completed.
 5. Sub-tasks show up as bullet points in the notes of their parent tasks.
+6. Markdown exports keep line breaks and nested bullets from the notes.
 
 Your access token is stored locally in your browser using `saveform`.

--- a/googletasks/script.js
+++ b/googletasks/script.js
@@ -30,10 +30,17 @@ const mergeSubtasks = (arr) => {
   });
   const fmt = (t, lvl = 0) => {
     const indent = "  ".repeat(lvl);
-    const note = (t.notes || "").replace(/\n+/g, " ").trim();
-    const link = (t.links || "").trim();
     const lines = [`${indent}- ${t.title}`];
-    if (note) lines.push(`${indent}  - ${note}`);
+    const notes = (t.notes || "").trim();
+    if (notes)
+      lines.push(
+        notes
+          .split("\n")
+          .filter(Boolean)
+          .map((l) => `${indent}  ${l}`)
+          .join("\n"),
+      );
+    const link = (t.links || "").trim();
     if (link) lines.push(`${indent}  - ${link}`);
     t.children.forEach((c) => lines.push(fmt(c, lvl + 1)));
     return lines.join("\n");
@@ -122,10 +129,17 @@ mdBtn.addEventListener("click", async () => {
     .filter((t) => t.status !== "completed")
     .map((t) => {
       const base = `- **${t.title}** #${t.list} (${fmtDate(t.updated)})`;
-      const notes = (t.notes || "").replace(/\n+/g, " ").trim();
+      const notes = (t.notes || "").trim();
       const links = (t.links || "").trim();
       const extras = [];
-      if (notes) extras.push(`  - ${notes}`);
+      if (notes)
+        extras.push(
+          notes
+            .split("\n")
+            .filter(Boolean)
+            .map((l) => `  ${l}`)
+            .join("\n"),
+        );
       if (links) extras.push(`  - ${links}`);
       return [base, ...extras].join("\n");
     })


### PR DESCRIPTION
## Summary
- include subtasks when fetching Google Tasks
- document how subtasks appear in exported notes

## Testing
- `npx -y prettier@3.5 --print-width=120 '**/*.js' '**/*.md'`
- `npx -y js-beautify@1 '**/googletasks/*.html' --type html --replace --indent-size 2 --max-preserve-newlines 1 --end-with-newline`
- `uvx ruff check . --line-length 100`


------
https://chatgpt.com/codex/tasks/task_e_688476dc3d28832ca8c8157b0afe1efd