### PR TITLE
Fix optional base image for AI Image Chat

### DIFF
--- a/imagegen/README.md
+++ b/imagegen/README.md
@@ -1,11 +1,11 @@
 # AI Image Chat
 
-Interactively generate and modify images using OpenAI's `gpt-image-1` model. Upload an image or paste a URL, describe the changes you want, and chat to refine the result. A few sample images are loaded from `config.json` to try out the tool quickly.
+Interactively generate and modify images using OpenAI's `gpt-image-1` model. Optionally upload an image or paste a URL, describe the changes you want, and chat to refine the result. A few sample images are loaded from `config.json` to try out the tool quickly.
 
 ## What it does
 
 1. **Image Selection**
-   - Upload an image or paste its URL.
+   - Optionally upload an image or paste its URL.
    - A set of sample images are provided as quick starting points.
 2. **Prompt-Based Editing**
    - Describe how you want the image updated. If no image is chosen, a brand new one is generated.
@@ -15,7 +15,7 @@ Interactively generate and modify images using OpenAI's `gpt-image-1` model. Upl
 ## How it works
 
 1. Configure your OpenAI key and select an allowed base URL from LLM Foundry.
-2. Upload an image or paste a URL and type a prompt describing your desired output.
+2. Optionally upload an image or paste a URL and type a prompt describing your desired output.
 3. If an image is provided, it is sent to the `/images/edits` endpoint. Otherwise `/images/generations` is used.
 4. The returned `b64_json` is displayed and becomes the new base image.
 5. Continue chatting with new prompts to iteratively improve the image.

--- a/imagegen/index.html
+++ b/imagegen/index.html
@@ -23,9 +23,9 @@
       <div class="col-md-8">
         <div class="p-4 bg-white rounded-3 shadow-sm h-100">
           <h2 class="fs-4 mb-2">Create and modify images through conversation</h2>
-          <p>Upload an image or paste its URL, describe your changes, and keep chatting to iterate.</p>
+          <p>Optionally upload an image or paste its URL, describe your changes, and keep chatting to iterate.</p>
           <ul class="list-unstyled mb-0">
-            <li class="mb-2"><i class="bi bi-cloud-upload me-2 text-secondary"></i>Upload or link to a starting image</li>
+            <li class="mb-2"><i class="bi bi-cloud-upload me-2 text-secondary"></i>Optionally upload or link to a starting image</li>
             <li class="mb-2"><i class="bi bi-pencil-square me-2 text-secondary"></i>Describe your changes and send</li>
             <li class="mb-2"><i class="bi bi-images me-2 text-secondary"></i>Get a new image and continue the chat</li>
           </ul>

--- a/imagegen/script.js
+++ b/imagegen/script.js
@@ -133,10 +133,7 @@ function addImageCard(url) {
 function selectImage() {
   if (baseImage || selectedUrl) return true;
   selectedUrl = ui.url.value.trim();
-  if (!selectedUrl) {
-    showToast({ title: "Image missing", body: "Upload or paste a URL", color: "bg-warning" });
-    return false;
-  }
+  if (!selectedUrl) return true;
   ui.preview.src = selectedUrl;
   ui.preview.classList.remove("d-none");
   return true;


### PR DESCRIPTION
## Summary
- allow using gpt-image-1 image generation when no source image is provided
- update docs and UI text to note that uploading an image is optional

## Testing
- `uvx ruff check --line-length 100`
- `npx -y prettier@3.5 --print-width=120 '**/*.js' '**/*.md'`
- `npx -y js-beautify@1 '**/*.html' --type html --replace --indent-size 2 --max-preserve-newlines 1 --end-with-newline`

------
https://chatgpt.com/codex/tasks/task_e_6885b42bf01c832c9747bc8e374b5b52