### PR TITLE
Enhance Recall with ⭐ filtering

### DIFF
--- a/recall/README.md
+++ b/recall/README.md
@@ -6,6 +6,7 @@ Recall is a spaced repetition viewer. It loads a Markdown file, picks a list ite
 
 - Choose from preset Markdown files
 - Adjustable decay factor for selection probability
-- "Another" and "Copy" buttons to cycle items or copy the Markdown
+- Random, Previous, Next, Copy, and ⭐ buttons for navigation and filtering
+- Editable index field to jump directly to a bullet
 
 This tool is mobile responsive and styled with Bootstrap, similar to the Podcast Generator tool.

--- a/recall/index.html
+++ b/recall/index.html
@@ -11,6 +11,18 @@
 </head>
 
 <body class="bg-light">
+  <div class="container-fluid text-center mt-4">
+    <div class="d-inline-flex flex-nowrap gap-2">
+      <select id="file-select" class="form-select form-select-sm w-auto"></select>
+      <input id="decay-input" type="number" class="form-control form-control-sm w-auto" min="0" max="1" step="0.01" value="0.02" style="max-width: 7rem" />
+      <input id="index-input" type="number" class="form-control form-control-sm w-auto" min="1" style="max-width: 6rem" />
+      <button id="prev-btn" class="btn btn-outline-primary btn-sm"><i class="bi bi-arrow-left"></i></button>
+      <button id="random-btn" class="btn btn-primary btn-sm"><i class="bi bi-shuffle"></i> Random</button>
+      <button id="next-btn" class="btn btn-outline-primary btn-sm"><i class="bi bi-arrow-right"></i></button>
+      <button id="star-btn" class="btn btn-outline-warning btn-sm"><i class="bi bi-star"></i></button>
+      <button id="copy-btn" class="btn btn-secondary btn-sm"><i class="bi bi-clipboard"></i> Copy</button>
+    </div>
+  </div>
   <div class="container py-4" style="max-width: 40rem">
     <header class="pb-3 mb-4 border-bottom">
       <div class="d-flex align-items-center">
@@ -24,18 +36,6 @@
       <div class="text-center">
         <div class="spinner-border" role="status"></div>
       </div>
-    </div>
-  </div>
-  <div class="container-fluid text-center mt-4">
-    <div class="d-inline-flex flex-nowrap gap-2">
-      <select id="file-select" class="form-select form-select-sm w-auto"></select>
-      <input id="decay-input" type="number" class="form-control form-control-sm w-auto" min="0" max="1" step="0.01" value="0.02" style="max-width: 7rem" />
-      <input id="index-input" type="number" class="form-control form-control-sm w-auto" min="1" style="max-width: 6rem" />
-      <button id="prev-btn" class="btn btn-outline-primary btn-sm"><i class="bi bi-arrow-left"></i></button>
-      <button id="random-btn" class="btn btn-primary btn-sm"><i class="bi bi-shuffle"></i> Random</button>
-      <button id="next-btn" class="btn btn-outline-primary btn-sm"><i class="bi bi-arrow-right"></i></button>
-      <button id="star-btn" class="btn btn-outline-warning btn-sm"><i class="bi bi-star"></i></button>
-      <button id="copy-btn" class="btn btn-secondary btn-sm"><i class="bi bi-clipboard"></i> Copy</button>
     </div>
   </div>
   <script src="https://cdn.jsdelivr.net/npm/bootstrap@5.3.6/dist/js/bootstrap.bundle.min.js" crossorigin="anonymous"></script>

--- a/recall/index.html
+++ b/recall/index.html
@@ -25,7 +25,9 @@
         <div class="spinner-border" role="status"></div>
       </div>
     </div>
-    <div class="d-flex flex-nowrap gap-2 mt-4">
+  </div>
+  <div class="container-fluid text-center mt-4">
+    <div class="d-inline-flex flex-nowrap gap-2">
       <select id="file-select" class="form-select form-select-sm w-auto"></select>
       <input id="decay-input" type="number" class="form-control form-control-sm w-auto" min="0" max="1" step="0.01" value="0.02" style="max-width: 7rem" />
       <input id="index-input" type="number" class="form-control form-control-sm w-auto" min="1" style="max-width: 6rem" />

--- a/recall/index.html
+++ b/recall/index.html
@@ -11,7 +11,7 @@
 </head>
 
 <body class="bg-light">
-  <div class="container py-4">
+  <div class="container py-4" style="max-width: 40rem">
     <header class="pb-3 mb-4 border-bottom">
       <div class="d-flex align-items-center">
         <i class="bi bi-clock-history fs-1 me-3 text-primary"></i>
@@ -28,7 +28,11 @@
     <div class="d-flex flex-nowrap gap-2 mt-4">
       <select id="file-select" class="form-select form-select-sm w-auto"></select>
       <input id="decay-input" type="number" class="form-control form-control-sm w-auto" min="0" max="1" step="0.01" value="0.02" style="max-width: 7rem" />
-      <button id="another-btn" class="btn btn-primary btn-sm"><i class="bi bi-shuffle"></i> Next</button>
+      <input id="index-input" type="number" class="form-control form-control-sm w-auto" min="1" style="max-width: 6rem" />
+      <button id="prev-btn" class="btn btn-outline-primary btn-sm"><i class="bi bi-arrow-left"></i></button>
+      <button id="random-btn" class="btn btn-primary btn-sm"><i class="bi bi-shuffle"></i> Random</button>
+      <button id="next-btn" class="btn btn-outline-primary btn-sm"><i class="bi bi-arrow-right"></i></button>
+      <button id="star-btn" class="btn btn-outline-warning btn-sm"><i class="bi bi-star"></i></button>
       <button id="copy-btn" class="btn btn-secondary btn-sm"><i class="bi bi-clipboard"></i> Copy</button>
     </div>
   </div>

--- a/recall/script.js
+++ b/recall/script.js
@@ -26,12 +26,18 @@ const files = [
 
 const content = document.getElementById("content");
 const fileSelect = document.getElementById("file-select");
-const anotherBtn = document.getElementById("another-btn");
+const randomBtn = document.getElementById("random-btn");
 const copyBtn = document.getElementById("copy-btn");
+const starBtn = document.getElementById("star-btn");
 const decayInput = document.getElementById("decay-input");
+const indexInput = document.getElementById("index-input");
+const prevBtn = document.getElementById("prev-btn");
+const nextBtn = document.getElementById("next-btn");
 const title = document.getElementById("title");
 let items = [];
-let current = "";
+let view = [];
+let index = 0;
+let starOnly = false;
 
 files.forEach((f) => fileSelect.insertAdjacentHTML("beforeend", `<option value="${f.url}">${f.name}</option>`));
 
@@ -46,7 +52,7 @@ async function load(url) {
       .lexer(text)
       .filter((t) => t.type === "list")
       .flatMap((l) => l.items.map((i) => i.raw.trim()));
-    pick();
+    applyFilter();
   } catch (e) {
     content.innerHTML = "";
     updateLatestToast({ title: "Error", body: e.message, color: "bg-danger" });
@@ -58,23 +64,53 @@ function weight(i) {
   return (1 - d) ** i;
 }
 
-function pick() {
-  const weights = items.map((_, i) => weight(i));
+function applyFilter() {
+  view = starOnly ? items.filter((t) => t.includes("⭐")) : items.slice();
+  if (!view.length) {
+    content.innerHTML = "";
+    indexInput.value = "";
+    updateLatestToast({ body: "No ⭐ items", color: "bg-danger" });
+    return;
+  }
+  randomPick();
+}
+
+function show(i) {
+  if (i < 0 || i >= view.length) {
+    updateLatestToast({ body: "Index out of range", color: "bg-danger" });
+    return;
+  }
+  index = i;
+  content.innerHTML = marked.parse(view[i]);
+  indexInput.value = i + 1;
+}
+
+function randomPick() {
+  const weights = view.map((_, i) => weight(i));
   const total = weights.reduce((a, b) => a + b, 0);
   let r = Math.random() * total;
   let i = 0;
   while (r >= weights[i]) r -= weights[i++];
-  current = items[i];
-  content.innerHTML = marked.parse(current);
+  show(i);
 }
 
 fileSelect.onchange = () => load(fileSelect.value);
-decayInput.oninput = pick;
-anotherBtn.onclick = pick;
-title.onclick = pick;
+decayInput.oninput = randomPick;
+randomBtn.onclick = randomPick;
+title.onclick = randomPick;
+prevBtn.onclick = () => show(index - 1);
+nextBtn.onclick = () => show(index + 1);
+indexInput.oninput = () => show(+indexInput.value - 1);
 copyBtn.onclick = async () => {
-  await navigator.clipboard.writeText(current);
+  await navigator.clipboard.writeText(view[index] || "");
   updateLatestToast({ body: "Copied", color: "bg-success" });
+};
+
+starBtn.onclick = () => {
+  starOnly = !starOnly;
+  starBtn.className = `btn btn-${starOnly ? "warning" : "outline-warning"} btn-sm`;
+  starBtn.innerHTML = `<i class="bi bi-${starOnly ? "star-fill" : "star"}"></i>`;
+  applyFilter();
 };
 
 load(files[0].url);


### PR DESCRIPTION
## Problem
Recall lacked a way to filter entries that contain a star symbol.

## Changes
- Added a star toggle button in `recall/index.html` for filtering
- Introduced `applyFilter()` and state handling in `recall/script.js`
- Updated `recall/README.md` to document new controls

## Review
- Changes confined to the `recall/` folder; visual inspection should suffice
- Pay attention to edge cases: filtering when no ⭐ items are present

## Verification
1. Run a local HTTP server and open `recall/index.html`
2. Load a file and toggle the ⭐ button
3. Use Prev/Next/Random and the index input to navigate while filtered
4. Confirm copy, error messages, and styling work as expected

## Deployment risks
Minimal; frontend-only changes. Clear browser cache to load updated JS.

## Learning
Illustrates how small UI enhancements improve usability and filtering options.

------
https://chatgpt.com/codex/tasks/task_e_6885b9c2d50c832ca802cd51eb1d2ff0