### PR TITLE
Add PicBook image sequence tool

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,6 +20,7 @@ A collection of single page web apps, mostly LLM generated. Hosted at [tools.s-a
 - **[Recall](./recall/)**: Randomly recall list items from Markdown.
 - **[Daydream](./daydream/)**: Browse and rate creative ideas stored as JSONL.
 - **[AI Image Chat](./imagegen/)**: Chat to generate or update images.
+- **[PicBook](./picbook/)**: Generate a sequence of images from multiline captions.
 - **[SpeakMD](./speakmd/)**: Converts Markdown into conversational text suitable for audio narration.
 - **[Quotes Arena](./quotesarena/)**: A web application that allows users to compare short, AI-generated quotes side-by-side and vote for their preferred one, tracking AI model performance.
 - **[RevealJS](./revealjs/)**: Provides a simple web interface to convert Markdown text into a Reveal.js HTML slideshow.

--- a/picbook/README.md
+++ b/picbook/README.md
@@ -14,7 +14,7 @@ PicBook turns a list of short captions into a sequence of images while keeping t
    - A progress bar shows how many panels are done and estimates total time.
    - You can pause after any panel and continue later.
 4. **Download**
-   - Each panel has a download button, and you can download all as a ZIP archive.
+   - Download all generated panels as a ZIP archive.
 
 ## How it works
 

--- a/picbook/README.md
+++ b/picbook/README.md
@@ -4,12 +4,12 @@ PicBook turns a list of short captions into a sequence of images while keeping t
 
 ## What it does
 
-1. **Context and Captions**
-   - Enter an overall description of the picture book's style.
-   - Provide one caption per line; each becomes an image.
+1. **Context and Panels**
+   - Enter common guidance for the whole book.
+   - Each line is `Caption text [Prompt for LLM]`.
 2. **Reference Image**
    - Optionally upload or link to an image so the first panel matches its style.
-   - Subsequent panels use the previous image as an additional reference.
+   - Later panels use both the original reference and the previous image.
 3. **Progress Tracking**
    - A progress bar shows how many panels are done and estimates total time.
    - You can pause after any panel and continue later.
@@ -19,6 +19,6 @@ PicBook turns a list of short captions into a sequence of images while keeping t
 ## How it works
 
 1. Configure your OpenAI API key and base URL.
-2. The first caption is sent to `/images/edits` if a reference is provided, otherwise to `/images/generations`.
-3. Each subsequent caption is sent along with the previous panel as the reference image to maintain consistency.
-4. Images are displayed as they arrive and can be individually downloaded or saved as a ZIP file.
+2. The first panel uses the uploaded image (or URL) if provided.
+3. Later panels also send the previous image for style consistency.
+4. Images appear as soon as they are ready and can be saved individually or as a ZIP.

--- a/picbook/README.md
+++ b/picbook/README.md
@@ -1,0 +1,24 @@
+# PicBook
+
+PicBook turns a list of short captions into a sequence of images while keeping the style consistent. You can provide a reference image or URL as inspiration, add some context about the story and desired style, and then generate one panel per line.
+
+## What it does
+
+1. **Context and Captions**
+   - Enter an overall description of the picture book's style.
+   - Provide one caption per line; each becomes an image.
+2. **Reference Image**
+   - Optionally upload or link to an image so the first panel matches its style.
+   - Subsequent panels use the previous image as an additional reference.
+3. **Progress Tracking**
+   - A progress bar shows how many panels are done and estimates total time.
+   - You can pause after any panel and continue later.
+4. **Download**
+   - Each panel has a download button, and you can download all as a ZIP archive.
+
+## How it works
+
+1. Configure your OpenAI API key and base URL.
+2. The first caption is sent to `/images/edits` if a reference is provided, otherwise to `/images/generations`.
+3. Each subsequent caption is sent along with the previous panel as the reference image to maintain consistency.
+4. Images are displayed as they arrive and can be individually downloaded or saved as a ZIP file.

--- a/picbook/index.html
+++ b/picbook/index.html
@@ -8,6 +8,22 @@
   <link rel="icon" type="image/svg+xml" href="data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 16 16'%3E%3Cpath fill='%230d6efd' d='M8 0l2 5h5l-4 3 2 5-4-3-4 3 2-5-4-3h5z'/%3E%3C/svg%3E" />
   <link href="https://cdn.jsdelivr.net/npm/bootstrap@5.3.6/dist/css/bootstrap.min.css" rel="stylesheet" />
   <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/bootstrap-icons@1.11.1/font/bootstrap-icons.css" />
+  <style>
+    @media print {
+      body> :not(#print-area) {
+        display: none !important
+      }
+
+      #print-area .card {
+        page-break-before: always
+      }
+
+      #print-area .card:first-child {
+        page-break-before: avoid
+      }
+    }
+
+  </style>
 </head>
 
 <body class="bg-light">
@@ -43,7 +59,7 @@
             <div class="col">
               <select id="quality" class="form-select form-select-sm">
                 <option>low</option>
-                <option>medium</option>
+                <option selected>medium</option>
                 <option>high</option>
                 <option>auto</option>
               </select>
@@ -87,9 +103,10 @@
       <span id="progress-text" class="small text-muted"></span>
       <button id="pause-btn" type="button" class="btn btn-outline-secondary"><i class="bi bi-pause-fill"></i></button>
       <button id="zip-btn" type="button" class="btn btn-outline-primary"><i class="bi bi-download"></i></button>
+      <button id="print-btn" type="button" class="btn btn-outline-secondary"><i class="bi bi-printer"></i></button>
     </div>
   </div>
-  <div class="container-fluid">
+  <div id="print-area" class="container-fluid">
     <div id="picbook-log" class="row g-3"></div>
   </div>
   <script src="https://cdn.jsdelivr.net/npm/bootstrap@5.3.6/dist/js/bootstrap.bundle.min.js"></script>

--- a/picbook/index.html
+++ b/picbook/index.html
@@ -20,70 +20,64 @@
     </header>
     <form id="picbook-form" class="bg-white rounded-3 shadow-sm p-3 mb-3">
       <div class="row g-3">
-        <div class="col-md-6">
+        <div class="col-lg-4">
           <label for="context" class="form-label">Context</label>
           <textarea id="context" rows="2" class="form-control" placeholder="Common guidance for all images, e.g. Draw anime style with bright colors"></textarea>
-        </div>
-        <div class="col-md-6">
-          <label for="panels" class="form-label">Panels</label>
-          <textarea id="panels" rows="6" class="form-control" placeholder="One line per panel, each in the format 'Text caption to display [Prompt for LLM]'"></textarea>
-        </div>
-      </div>
-      <div class="row g-3 mt-0">
-        <div class="col-md-6">
-          <input type="file" id="upload-input" accept="image/*" class="form-control" />
+          <input type="file" id="upload-input" accept="image/*" class="form-control mt-2" />
           <img id="preview-image" class="img-fluid rounded mt-2 d-none" alt="Preview" />
           <input type="text" id="image-url" placeholder="Reference image URL" class="form-control mt-2" />
+          <h4 class="h6 mt-3">Advanced options</h4>
+          <div class="row g-2 mb-2 align-items-center">
+            <label for="size" class="col-4 col-form-label">Size</label>
+            <div class="col">
+              <select id="size" class="form-select form-select-sm">
+                <option>auto</option>
+                <option>1024x1024</option>
+                <option>1536x1024</option>
+                <option>1024x1536</option>
+              </select>
+            </div>
+          </div>
+          <div class="row g-2 mb-2 align-items-center">
+            <label for="quality" class="col-4 col-form-label">Quality</label>
+            <div class="col">
+              <select id="quality" class="form-select form-select-sm">
+                <option>low</option>
+                <option>medium</option>
+                <option>high</option>
+                <option>auto</option>
+              </select>
+            </div>
+          </div>
+          <div class="row g-2 mb-2 align-items-center">
+            <label for="output-format" class="col-4 col-form-label">Format</label>
+            <div class="col">
+              <select id="output-format" class="form-select form-select-sm">
+                <option>webp</option>
+                <option>png</option>
+                <option>jpeg</option>
+              </select>
+            </div>
+          </div>
+          <div class="row g-2 mb-2 align-items-center">
+            <label for="output-compression" class="col-4 col-form-label">Compression</label>
+            <div class="col">
+              <input type="number" id="output-compression" value="50" min="0" max="100" class="form-control form-control-sm" />
+            </div>
+          </div>
+          <div class="form-check form-switch mb-3">
+            <input id="background" type="checkbox" class="form-check-input" />
+            <label class="form-check-label" for="background">Transparent background</label>
+          </div>
         </div>
-        <div class="col-md-6 text-end">
-          <button id="openai-config-btn" type="button" class="btn btn-outline-secondary"><i class="bi bi-gear me-1"></i>Configure OpenAI</button>
+        <div class="col-lg-8">
+          <label for="panels" class="form-label">Panels</label>
+          <textarea id="panels" rows="16" class="form-control" placeholder="One line per panel, each in the format 'Text caption to display [Prompt for LLM]'"></textarea>
+          <div class="d-flex justify-content-end gap-2 mt-2">
+            <button id="openai-config-btn" type="button" class="btn btn-outline-secondary"><i class="bi bi-gear me-1"></i>Configure OpenAI</button>
+            <button id="start-btn" class="btn btn-primary" type="submit"><i class="bi bi-play-fill me-1"></i>Start</button>
+          </div>
         </div>
-      </div>
-      <h4 class="h6 mt-3">Advanced options</h4>
-      <div class="row g-2 mb-2 align-items-center">
-        <label for="size" class="col-4 col-form-label">Size</label>
-        <div class="col">
-          <select id="size" class="form-select form-select-sm">
-            <option>auto</option>
-            <option>1024x1024</option>
-            <option>1536x1024</option>
-            <option>1024x1536</option>
-          </select>
-        </div>
-      </div>
-      <div class="row g-2 mb-2 align-items-center">
-        <label for="quality" class="col-4 col-form-label">Quality</label>
-        <div class="col">
-          <select id="quality" class="form-select form-select-sm">
-            <option>low</option>
-            <option>medium</option>
-            <option>high</option>
-            <option>auto</option>
-          </select>
-        </div>
-      </div>
-      <div class="row g-2 mb-2 align-items-center">
-        <label for="output-format" class="col-4 col-form-label">Format</label>
-        <div class="col">
-          <select id="output-format" class="form-select form-select-sm">
-            <option>webp</option>
-            <option>png</option>
-            <option>jpeg</option>
-          </select>
-        </div>
-      </div>
-      <div class="row g-2 mb-2 align-items-center">
-        <label for="output-compression" class="col-4 col-form-label">Compression</label>
-        <div class="col">
-          <input type="number" id="output-compression" value="50" min="0" max="100" class="form-control form-control-sm" />
-        </div>
-      </div>
-      <div class="form-check form-switch mb-3">
-        <input id="background" type="checkbox" class="form-check-input" />
-        <label class="form-check-label" for="background">Transparent background</label>
-      </div>
-      <div class="text-end">
-        <button id="start-btn" class="btn btn-primary" type="submit"><i class="bi bi-play-fill me-1"></i>Start</button>
       </div>
     </form>
     <div id="progress-row" class="d-flex align-items-center gap-2 mb-3 d-none">

--- a/picbook/index.html
+++ b/picbook/index.html
@@ -9,17 +9,31 @@
   <link href="https://cdn.jsdelivr.net/npm/bootstrap@5.3.6/dist/css/bootstrap.min.css" rel="stylesheet" />
   <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/bootstrap-icons@1.11.1/font/bootstrap-icons.css" />
   <style>
+    .download-btn {
+      opacity: 0;
+      transition: opacity 0.2s;
+    }
+
+    .card:hover .download-btn {
+      opacity: 1;
+    }
+
     @media print {
       body> :not(#print-area) {
-        display: none !important
+        display: none !important;
       }
 
-      #print-area .card {
-        page-break-before: always
+      #picbook-log>* {
+        page-break-before: always;
+        zoom: 1.5;
       }
 
-      #print-area .card:first-child {
-        page-break-before: avoid
+      #picbook-log> :first-child {
+        page-break-before: avoid;
+      }
+
+      .download-btn {
+        display: none !important;
       }
     }
 
@@ -90,8 +104,9 @@
           <label for="panels" class="form-label">Panels</label>
           <textarea id="panels" rows="16" class="form-control" placeholder="One line per panel, each in the format 'Text caption to display [Prompt for LLM]'"></textarea>
           <div class="d-flex justify-content-end gap-2 mt-2">
-            <button id="openai-config-btn" type="button" class="btn btn-outline-secondary"><i class="bi bi-gear me-1"></i>Configure OpenAI</button>
             <button id="start-btn" class="btn btn-primary" type="submit"><i class="bi bi-play-fill me-1"></i>Start</button>
+            <button id="openai-config-btn" type="button" class="btn btn-outline-secondary"><i class="bi bi-gear me-1"></i>Configure OpenAI</button>
+            <button type="reset" class="btn btn-outline-secondary"><i class="bi bi-arrow-counterclockwise me-1"></i>Reset</button>
           </div>
         </div>
       </div>

--- a/picbook/index.html
+++ b/picbook/index.html
@@ -9,15 +9,6 @@
   <link href="https://cdn.jsdelivr.net/npm/bootstrap@5.3.6/dist/css/bootstrap.min.css" rel="stylesheet" />
   <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/bootstrap-icons@1.11.1/font/bootstrap-icons.css" />
   <style>
-    .download-btn {
-      opacity: 0;
-      transition: opacity 0.2s;
-    }
-
-    .card:hover .download-btn {
-      opacity: 1;
-    }
-
     @media print {
       body> :not(#print-area) {
         display: none !important;
@@ -30,10 +21,6 @@
 
       #picbook-log> :first-child {
         page-break-before: avoid;
-      }
-
-      .download-btn {
-        display: none !important;
       }
     }
 
@@ -61,7 +48,6 @@
             <label for="size" class="col-4 col-form-label">Size</label>
             <div class="col">
               <select id="size" class="form-select form-select-sm">
-                <option>auto</option>
                 <option>1024x1024</option>
                 <option>1536x1024</option>
                 <option>1024x1536</option>

--- a/picbook/index.html
+++ b/picbook/index.html
@@ -1,0 +1,100 @@
+<!doctype html>
+<html lang="en">
+
+<head>
+  <meta charset="UTF-8" />
+  <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+  <title>PicBook</title>
+  <link rel="icon" type="image/svg+xml" href="data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 16 16'%3E%3Cpath fill='%230d6efd' d='M8 0l2 5h5l-4 3 2 5-4-3-4 3 2-5-4-3h5z'/%3E%3C/svg%3E" />
+  <link href="https://cdn.jsdelivr.net/npm/bootstrap@5.3.6/dist/css/bootstrap.min.css" rel="stylesheet" />
+  <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/bootstrap-icons@1.11.1/font/bootstrap-icons.css" />
+</head>
+
+<body class="bg-light">
+  <div class="container py-4">
+    <header class="pb-3 mb-4 border-bottom">
+      <div class="d-flex align-items-center">
+        <i class="bi bi-images fs-1 me-3 text-primary"></i>
+        <h1 class="display-5 fw-bold">PicBook</h1>
+      </div>
+    </header>
+    <form id="picbook-form" class="row g-4 mb-4">
+      <div class="col-md-4">
+        <div class="p-3 bg-white rounded-3 shadow-sm h-100">
+          <div class="mb-3">
+            <label for="context" class="form-label">Context</label>
+            <textarea id="context" rows="2" class="form-control" placeholder="e.g. A brave cat explores space in anime style"></textarea>
+          </div>
+          <div class="mb-3">
+            <label for="captions" class="form-label">Captions</label>
+            <textarea id="captions" rows="6" class="form-control" placeholder="One caption per line\nThe cat boards a rocket\nStars twinkle as it lifts off"></textarea>
+          </div>
+          <div class="mb-3">
+            <input type="file" id="upload-input" accept="image/*" class="form-control" />
+            <img id="preview-image" class="img-fluid rounded mt-2 d-none" alt="Preview" />
+            <input type="text" id="image-url" placeholder="Reference image URL" class="form-control mt-2" />
+          </div>
+          <button id="openai-config-btn" type="button" class="btn btn-outline-secondary w-100 mb-3">Configure OpenAI</button>
+          <h4 class="h6">Advanced options</h4>
+          <div class="row g-2 mb-2 align-items-center">
+            <label for="size" class="col-4 col-form-label">Size</label>
+            <div class="col">
+              <select id="size" class="form-select form-select-sm">
+                <option>auto</option>
+                <option>1024x1024</option>
+                <option>1536x1024</option>
+                <option>1024x1536</option>
+              </select>
+            </div>
+          </div>
+          <div class="row g-2 mb-2 align-items-center">
+            <label for="quality" class="col-4 col-form-label">Quality</label>
+            <div class="col">
+              <select id="quality" class="form-select form-select-sm">
+                <option>low</option>
+                <option>medium</option>
+                <option>high</option>
+                <option>auto</option>
+              </select>
+            </div>
+          </div>
+          <div class="row g-2 mb-2 align-items-center">
+            <label for="output-format" class="col-4 col-form-label">Format</label>
+            <div class="col">
+              <select id="output-format" class="form-select form-select-sm">
+                <option>webp</option>
+                <option>png</option>
+                <option>jpeg</option>
+              </select>
+            </div>
+          </div>
+          <div class="row g-2 mb-2 align-items-center">
+            <label for="output-compression" class="col-4 col-form-label">Compression</label>
+            <div class="col">
+              <input type="number" id="output-compression" value="50" min="0" max="100" class="form-control form-control-sm" />
+            </div>
+          </div>
+          <div class="form-check form-switch mb-3">
+            <input id="background" type="checkbox" class="form-check-input" />
+            <label class="form-check-label" for="background">Transparent background</label>
+          </div>
+          <div class="d-grid gap-2">
+            <button id="start-btn" class="btn btn-primary" type="submit">Start</button>
+            <button id="pause-btn" type="button" class="btn btn-outline-secondary d-none">Pause</button>
+            <button id="zip-btn" type="button" class="btn btn-outline-primary d-none"><i class="bi bi-download me-2"></i>Download ZIP</button>
+          </div>
+          <div id="progress" class="progress mt-3 d-none">
+            <div id="progress-bar" class="progress-bar" role="progressbar"></div>
+          </div>
+        </div>
+      </div>
+      <div class="col-md-8">
+        <div id="picbook-log" class="p-3 bg-white rounded-3 shadow-sm h-100 overflow-auto"></div>
+      </div>
+    </form>
+  </div>
+  <script src="https://cdn.jsdelivr.net/npm/bootstrap@5.3.6/dist/js/bootstrap.bundle.min.js"></script>
+  <script type="module" src="script.js"></script>
+</body>
+
+</html>

--- a/picbook/index.html
+++ b/picbook/index.html
@@ -18,80 +18,85 @@
         <h1 class="display-5 fw-bold">PicBook</h1>
       </div>
     </header>
-    <form id="picbook-form" class="row g-4 mb-4">
-      <div class="col-md-4">
-        <div class="p-3 bg-white rounded-3 shadow-sm h-100">
-          <div class="mb-3">
-            <label for="context" class="form-label">Context</label>
-            <textarea id="context" rows="2" class="form-control" placeholder="e.g. A brave cat explores space in anime style"></textarea>
-          </div>
-          <div class="mb-3">
-            <label for="captions" class="form-label">Captions</label>
-            <textarea id="captions" rows="6" class="form-control" placeholder="One caption per line\nThe cat boards a rocket\nStars twinkle as it lifts off"></textarea>
-          </div>
-          <div class="mb-3">
-            <input type="file" id="upload-input" accept="image/*" class="form-control" />
-            <img id="preview-image" class="img-fluid rounded mt-2 d-none" alt="Preview" />
-            <input type="text" id="image-url" placeholder="Reference image URL" class="form-control mt-2" />
-          </div>
-          <button id="openai-config-btn" type="button" class="btn btn-outline-secondary w-100 mb-3">Configure OpenAI</button>
-          <h4 class="h6">Advanced options</h4>
-          <div class="row g-2 mb-2 align-items-center">
-            <label for="size" class="col-4 col-form-label">Size</label>
-            <div class="col">
-              <select id="size" class="form-select form-select-sm">
-                <option>auto</option>
-                <option>1024x1024</option>
-                <option>1536x1024</option>
-                <option>1024x1536</option>
-              </select>
-            </div>
-          </div>
-          <div class="row g-2 mb-2 align-items-center">
-            <label for="quality" class="col-4 col-form-label">Quality</label>
-            <div class="col">
-              <select id="quality" class="form-select form-select-sm">
-                <option>low</option>
-                <option>medium</option>
-                <option>high</option>
-                <option>auto</option>
-              </select>
-            </div>
-          </div>
-          <div class="row g-2 mb-2 align-items-center">
-            <label for="output-format" class="col-4 col-form-label">Format</label>
-            <div class="col">
-              <select id="output-format" class="form-select form-select-sm">
-                <option>webp</option>
-                <option>png</option>
-                <option>jpeg</option>
-              </select>
-            </div>
-          </div>
-          <div class="row g-2 mb-2 align-items-center">
-            <label for="output-compression" class="col-4 col-form-label">Compression</label>
-            <div class="col">
-              <input type="number" id="output-compression" value="50" min="0" max="100" class="form-control form-control-sm" />
-            </div>
-          </div>
-          <div class="form-check form-switch mb-3">
-            <input id="background" type="checkbox" class="form-check-input" />
-            <label class="form-check-label" for="background">Transparent background</label>
-          </div>
-          <div class="d-grid gap-2">
-            <button id="start-btn" class="btn btn-primary" type="submit">Start</button>
-            <button id="pause-btn" type="button" class="btn btn-outline-secondary d-none">Pause</button>
-            <button id="zip-btn" type="button" class="btn btn-outline-primary d-none"><i class="bi bi-download me-2"></i>Download ZIP</button>
-          </div>
-          <div id="progress" class="progress mt-3 d-none">
-            <div id="progress-bar" class="progress-bar" role="progressbar"></div>
-          </div>
+    <form id="picbook-form" class="bg-white rounded-3 shadow-sm p-3 mb-3">
+      <div class="row g-3">
+        <div class="col-md-6">
+          <label for="context" class="form-label">Context</label>
+          <textarea id="context" rows="2" class="form-control" placeholder="Common guidance for all images, e.g. Draw anime style with bright colors"></textarea>
+        </div>
+        <div class="col-md-6">
+          <label for="panels" class="form-label">Panels</label>
+          <textarea id="panels" rows="6" class="form-control" placeholder="One line per panel, each in the format 'Text caption to display [Prompt for LLM]'"></textarea>
         </div>
       </div>
-      <div class="col-md-8">
-        <div id="picbook-log" class="p-3 bg-white rounded-3 shadow-sm h-100 overflow-auto"></div>
+      <div class="row g-3 mt-0">
+        <div class="col-md-6">
+          <input type="file" id="upload-input" accept="image/*" class="form-control" />
+          <img id="preview-image" class="img-fluid rounded mt-2 d-none" alt="Preview" />
+          <input type="text" id="image-url" placeholder="Reference image URL" class="form-control mt-2" />
+        </div>
+        <div class="col-md-6 text-end">
+          <button id="openai-config-btn" type="button" class="btn btn-outline-secondary"><i class="bi bi-gear me-1"></i>Configure OpenAI</button>
+        </div>
+      </div>
+      <h4 class="h6 mt-3">Advanced options</h4>
+      <div class="row g-2 mb-2 align-items-center">
+        <label for="size" class="col-4 col-form-label">Size</label>
+        <div class="col">
+          <select id="size" class="form-select form-select-sm">
+            <option>auto</option>
+            <option>1024x1024</option>
+            <option>1536x1024</option>
+            <option>1024x1536</option>
+          </select>
+        </div>
+      </div>
+      <div class="row g-2 mb-2 align-items-center">
+        <label for="quality" class="col-4 col-form-label">Quality</label>
+        <div class="col">
+          <select id="quality" class="form-select form-select-sm">
+            <option>low</option>
+            <option>medium</option>
+            <option>high</option>
+            <option>auto</option>
+          </select>
+        </div>
+      </div>
+      <div class="row g-2 mb-2 align-items-center">
+        <label for="output-format" class="col-4 col-form-label">Format</label>
+        <div class="col">
+          <select id="output-format" class="form-select form-select-sm">
+            <option>webp</option>
+            <option>png</option>
+            <option>jpeg</option>
+          </select>
+        </div>
+      </div>
+      <div class="row g-2 mb-2 align-items-center">
+        <label for="output-compression" class="col-4 col-form-label">Compression</label>
+        <div class="col">
+          <input type="number" id="output-compression" value="50" min="0" max="100" class="form-control form-control-sm" />
+        </div>
+      </div>
+      <div class="form-check form-switch mb-3">
+        <input id="background" type="checkbox" class="form-check-input" />
+        <label class="form-check-label" for="background">Transparent background</label>
+      </div>
+      <div class="text-end">
+        <button id="start-btn" class="btn btn-primary" type="submit"><i class="bi bi-play-fill me-1"></i>Start</button>
       </div>
     </form>
+    <div id="progress-row" class="d-flex align-items-center gap-2 mb-3 d-none">
+      <div class="progress flex-grow-1" style="height: 20px">
+        <div id="progress-bar" class="progress-bar" role="progressbar"></div>
+      </div>
+      <span id="progress-text" class="small text-muted"></span>
+      <button id="pause-btn" type="button" class="btn btn-outline-secondary"><i class="bi bi-pause-fill"></i></button>
+      <button id="zip-btn" type="button" class="btn btn-outline-primary"><i class="bi bi-download"></i></button>
+    </div>
+  </div>
+  <div class="container-fluid">
+    <div id="picbook-log" class="row g-3"></div>
   </div>
   <script src="https://cdn.jsdelivr.net/npm/bootstrap@5.3.6/dist/js/bootstrap.bundle.min.js"></script>
   <script type="module" src="script.js"></script>

--- a/picbook/script.js
+++ b/picbook/script.js
@@ -142,7 +142,7 @@ function createCard(caption, ratioClass, ratioStyle) {
 
 function setSpinner(card, show) {
   const body = card.querySelector(".card-body");
-  body.innerHTML = show ? '<div class="spinner-border"></div>' : "";
+  body.innerHTML = show ? '<div class="d-flex justify-content-center align-items-center"><div class="spinner-border"></div></div>' : "";
 }
 
 async function downloadZip() {

--- a/picbook/script.js
+++ b/picbook/script.js
@@ -18,6 +18,7 @@ const ui = {
   startBtn: document.getElementById("start-btn"),
   pauseBtn: document.getElementById("pause-btn"),
   zipBtn: document.getElementById("zip-btn"),
+  printBtn: document.getElementById("print-btn"),
   progressRow: document.getElementById("progress-row"),
   bar: document.getElementById("progress-bar"),
   progText: document.getElementById("progress-text"),
@@ -121,6 +122,7 @@ ui.url.oninput = () => {
 };
 
 ui.zipBtn.onclick = downloadZip;
+ui.printBtn.onclick = () => window.print();
 
 function createCard(caption) {
   ui.log.insertAdjacentHTML(
@@ -225,6 +227,7 @@ async function run() {
     if (index) refs.push(cards[index - 1].querySelector("img")?.src);
     const fullPrompt = ctx ? `${ctx} ${prompt}` : prompt;
     const t0 = performance.now();
+    const body = cards[index].querySelector(".card-body");
     setSpinner(cards[index], true);
     try {
       const resp = await requestImage(fullPrompt, refs, opts);
@@ -233,8 +236,9 @@ async function run() {
       const b64 = data.data?.[0]?.b64_json;
       if (!b64) throw new Error("No image returned");
       const imgUrl = `data:image/${ui.format.value};base64,${b64}`;
-      cards[index].innerHTML =
-        `<img src="${imgUrl}" title="${caption}" alt="${caption}" class="card-img-top object-fit-contain" style="height:250px"><div class="card-body p-2"><a download="${String(index + 1).padStart(3, "0")}-${slug(caption)}.${ui.format.value}" href="${imgUrl}" class="btn btn-sm btn-outline-secondary"><i class="bi bi-download"></i></a></div>`;
+      body.innerHTML =
+        `<img src="${imgUrl}" title="${caption}" alt="${caption}" class="img-fluid object-fit-contain" style="height:250px">` +
+        `<div class="mt-2"><a download="${String(index + 1).padStart(3, "0")}-${slug(caption)}.${ui.format.value}" href="${imgUrl}" class="btn btn-sm btn-outline-secondary"><i class="bi bi-download"></i></a></div>`;
       times.push((performance.now() - t0) / 1000);
       index++;
       updateProgress(index, panels.length);

--- a/picbook/script.js
+++ b/picbook/script.js
@@ -1,0 +1,232 @@
+import saveform from "https://cdn.jsdelivr.net/npm/saveform@1.2";
+import { openaiConfig } from "https://cdn.jsdelivr.net/npm/bootstrap-llm-provider@1.1";
+import { bootstrapAlert } from "https://cdn.jsdelivr.net/npm/bootstrap-alert@1";
+import JSZip from "https://cdn.jsdelivr.net/npm/jszip@3/+esm";
+
+const DEFAULT_BASE_URLS = [
+  "https://api.openai.com/v1",
+  "https://llmfoundry.straivedemo.com/openai/v1",
+  "https://llmfoundry.straive.com/openai/v1",
+];
+
+saveform("#picbook-form", { exclude: '[type="file"]' });
+
+const ui = {
+  form: document.getElementById("picbook-form"),
+  context: document.getElementById("context"),
+  captions: document.getElementById("captions"),
+  startBtn: document.getElementById("start-btn"),
+  pauseBtn: document.getElementById("pause-btn"),
+  zipBtn: document.getElementById("zip-btn"),
+  progress: document.getElementById("progress"),
+  bar: document.getElementById("progress-bar"),
+  log: document.getElementById("picbook-log"),
+  upload: document.getElementById("upload-input"),
+  url: document.getElementById("image-url"),
+  preview: document.getElementById("preview-image"),
+  configBtn: document.getElementById("openai-config-btn"),
+  size: document.getElementById("size"),
+  quality: document.getElementById("quality"),
+  format: document.getElementById("output-format"),
+  compression: document.getElementById("output-compression"),
+  background: document.getElementById("background"),
+};
+
+let aiConfig = await openaiConfig({ defaultBaseUrls: DEFAULT_BASE_URLS });
+ui.configBtn.addEventListener("click", async () => {
+  aiConfig = await openaiConfig({ defaultBaseUrls: DEFAULT_BASE_URLS, show: true });
+});
+
+let baseFile = null;
+let baseUrl = "";
+let cards = [];
+let state = "idle";
+let startTime = 0;
+let index = 0;
+const times = [];
+
+const slug = (t) =>
+  t
+    .toLowerCase()
+    .replace(/[^a-z0-9]+/g, "-")
+    .replace(/^-|-$/g, "")
+    .slice(0, 50);
+
+function collectOptions() {
+  const opts = { moderation: "low" };
+  if (ui.size.value !== "auto") opts.size = ui.size.value;
+  if (ui.quality.value !== "auto") opts.quality = ui.quality.value;
+  if (ui.format.value !== "png") {
+    opts.output_format = ui.format.value;
+    opts.output_compression = +ui.compression.value;
+  }
+  if (ui.background.checked) opts.background = "transparent";
+  return opts;
+}
+
+function updateProgress(current, total) {
+  const elapsed = (Date.now() - startTime) / 1000;
+  const avg = times.length ? times.reduce((a, b) => a + b, 0) / times.length : 60;
+  const est = avg * total;
+  ui.bar.style.width = `${(current / total) * 100}%`;
+  ui.bar.textContent = `${current}/${total} - ${Math.round(elapsed)}s / ~${Math.round(est)}s`;
+}
+
+function setState(s) {
+  state = s;
+  ui.pauseBtn.disabled = false;
+  ui.pauseBtn.classList.toggle("d-none", s === "idle");
+  if (s === "running") ui.pauseBtn.textContent = "Pause";
+  else if (s === "pausing") ui.pauseBtn.textContent = "Pausing...";
+  else if (s === "paused") ui.pauseBtn.textContent = "Continue";
+  else {
+    ui.pauseBtn.textContent = "Done";
+    ui.pauseBtn.disabled = true;
+  }
+}
+
+ui.pauseBtn.onclick = () => {
+  if (state === "running") setState("pausing");
+  else if (state === "paused") run();
+};
+
+ui.upload.onchange = () => {
+  const file = ui.upload.files[0];
+  if (!file) return;
+  baseFile = file;
+  baseUrl = "";
+  ui.url.value = "";
+  ui.preview.src = URL.createObjectURL(file);
+  ui.preview.classList.remove("d-none");
+};
+
+ui.url.oninput = () => {
+  const url = ui.url.value.trim();
+  if (!url) {
+    ui.preview.classList.add("d-none");
+    baseUrl = "";
+    return;
+  }
+  baseUrl = url;
+  baseFile = null;
+  ui.upload.value = "";
+  ui.preview.src = url;
+  ui.preview.classList.remove("d-none");
+};
+
+ui.zipBtn.onclick = downloadZip;
+
+function createCard(caption) {
+  ui.log.insertAdjacentHTML(
+    "beforeend",
+    `<div class="card mb-3 text-center picture-card"><div class="card-body"><div class="spinner-border m-5" role="status"></div><div class="small opacity-75 mt-3">${caption}</div></div></div>`,
+  );
+  return ui.log.lastElementChild;
+}
+
+async function downloadZip() {
+  if (!cards.length) return;
+  const zip = new JSZip();
+  for (const card of cards) {
+    const img = card.querySelector("img");
+    if (!img) continue;
+    const blob = await fetch(img.src).then((r) => r.blob());
+    const ext = img.src.split(";")[0].split("/")[1] || "png";
+    zip.file(`${String(cards.indexOf(card) + 1).padStart(3, "0")}-${slug(img.alt)}.${ext}`, blob);
+  }
+  const content = await zip.generateAsync({ type: "blob" });
+  const a = document.createElement("a");
+  a.href = URL.createObjectURL(content);
+  a.download = "picbook.zip";
+  a.click();
+  URL.revokeObjectURL(a.href);
+}
+
+async function requestImage(prompt, reference, opts) {
+  const { apiKey, baseURL } = aiConfig;
+  if (!apiKey) {
+    bootstrapAlert({ title: "OpenAI key missing", body: "Configure your key", color: "warning" });
+    return null;
+  }
+  if (reference) {
+    const blob = await fetch(reference).then((r) => r.blob());
+    const form = new FormData();
+    form.append("model", "gpt-image-1");
+    form.append("prompt", prompt);
+    form.append("n", "1");
+    Object.entries(opts).forEach(([k, v]) => form.append(k, v));
+    form.append("image", blob, "image.png");
+    return fetch(`${baseURL}/images/edits`, {
+      method: "POST",
+      headers: { Authorization: `Bearer ${apiKey}` },
+      body: form,
+    });
+  }
+  return fetch(`${baseURL}/images/generations`, {
+    method: "POST",
+    headers: { "Content-Type": "application/json", Authorization: `Bearer ${apiKey}` },
+    body: JSON.stringify({ model: "gpt-image-1", prompt, n: 1, ...opts }),
+  });
+}
+
+async function run() {
+  const captions = ui.captions.value
+    .split("\n")
+    .map((l) => l.trim())
+    .filter(Boolean);
+  if (!captions.length) {
+    bootstrapAlert({ title: "Captions missing", color: "warning" });
+    return;
+  }
+  if (state === "idle") {
+    ui.log.innerHTML = "";
+    cards = captions.map(createCard);
+    index = 0;
+    startTime = Date.now();
+    times.length = 0;
+  }
+  setState("running");
+  ui.progress.classList.remove("d-none");
+  ui.zipBtn.classList.remove("d-none");
+  const opts = collectOptions();
+  const ctx = ui.context.value.trim();
+  while (index < captions.length && state === "running") {
+    const caption = captions[index];
+    const prompt = ctx ? `${ctx} ${caption}` : caption;
+    const reference =
+      index === 0 ? (baseFile ? URL.createObjectURL(baseFile) : baseUrl) : cards[index - 1].querySelector("img")?.src;
+    const t0 = performance.now();
+    try {
+      const resp = await requestImage(prompt, reference, opts);
+      if (!resp || !resp.ok) throw new Error(await resp.text());
+      const data = await resp.json();
+      const b64 = data.data?.[0]?.b64_json;
+      if (!b64) throw new Error("No image returned");
+      const imgUrl = `data:image/${ui.format.value};base64,${b64}`;
+      cards[index].innerHTML =
+        `<img src="${imgUrl}" title="${caption}" alt="${caption}" class="card-img-top object-fit-contain" style="height:250px"><div class="card-body p-2"><a download="${String(index + 1).padStart(3, "0")}-${slug(caption)}.${ui.format.value}" href="${imgUrl}" class="btn btn-sm btn-outline-secondary"><i class="bi bi-download"></i></a></div>`;
+      times.push((performance.now() - t0) / 1000);
+      index++;
+      updateProgress(index, captions.length);
+    } catch (err) {
+      cards[index].querySelector(".spinner-border")?.remove();
+      bootstrapAlert({ title: caption, body: err.message, color: "danger" });
+      setState("paused");
+      return;
+    }
+    if (state === "pausing") {
+      setState("paused");
+      return;
+    }
+  }
+  if (index >= captions.length) setState("done");
+}
+
+ui.startBtn.onclick = (e) => {
+  e.preventDefault();
+  run();
+};
+ui.form.addEventListener("submit", (e) => {
+  e.preventDefault();
+  run();
+});

--- a/picbook/script.js
+++ b/picbook/script.js
@@ -36,7 +36,10 @@ const ui = {
 
 let aiConfig = await openaiConfig({ defaultBaseUrls: DEFAULT_BASE_URLS });
 ui.configBtn.addEventListener("click", async () => {
-  aiConfig = await openaiConfig({ defaultBaseUrls: DEFAULT_BASE_URLS, show: true });
+  aiConfig = await openaiConfig({
+    defaultBaseUrls: DEFAULT_BASE_URLS,
+    show: true,
+  });
 });
 
 let baseFile = null;
@@ -128,14 +131,9 @@ function createCard(caption, ratioClass, ratioStyle) {
   ui.log.insertAdjacentHTML(
     "beforeend",
     `<div class="col-md-6 col-lg-4 col-xl-3">
-       <div class="card p-0 text-center position-relative h-100">
-         <div class="card-header small opacity-75 px-2 py-1" contenteditable="true">${caption}</div>
-         <div class="${ratioClass}" style="${ratioStyle}">
-           <div class="card-body d-flex justify-content-center align-items-center h-100"></div>
-         </div>
-         <a class="download-btn btn btn-outline-secondary btn-sm position-absolute top-0 end-0 m-2" href="#" download>
-           <i class="bi bi-download"></i>
-         </a>
+       <div class="card overflow-hidden p-0 text-center position-relative h-100">
+         <div class="card-header text-bg-warning small opacity-75 px-2 py-1" contenteditable="true">${caption}</div>
+         <div class="card-body d-flex justify-content-center align-items-center h-100 p-0 ${ratioClass}" style="${ratioStyle}"></div>
        </div>
      </div>`,
   );
@@ -145,7 +143,6 @@ function createCard(caption, ratioClass, ratioStyle) {
 function setSpinner(card, show) {
   const body = card.querySelector(".card-body");
   body.innerHTML = show ? '<div class="spinner-border"></div>' : "";
-  card.querySelector(".download-btn").classList.toggle("invisible", show);
 }
 
 async function downloadZip() {
@@ -169,7 +166,11 @@ async function downloadZip() {
 async function requestImage(prompt, refs, opts) {
   const { apiKey, baseURL } = aiConfig;
   if (!apiKey) {
-    bootstrapAlert({ title: "OpenAI key missing", body: "Configure your key", color: "warning" });
+    bootstrapAlert({
+      title: "OpenAI key missing",
+      body: "Configure your key",
+      color: "warning",
+    });
     return null;
   }
   if (refs.length) {
@@ -191,7 +192,10 @@ async function requestImage(prompt, refs, opts) {
   }
   return fetch(`${baseURL}/images/generations`, {
     method: "POST",
-    headers: { "Content-Type": "application/json", Authorization: `Bearer ${apiKey}` },
+    headers: {
+      "Content-Type": "application/json",
+      Authorization: `Bearer ${apiKey}`,
+    },
     body: JSON.stringify({ model: "gpt-image-1", prompt, n: 1, ...opts }),
   });
 }
@@ -208,7 +212,11 @@ async function run() {
   const panels = lines.map((l) => {
     const i = l.indexOf("[");
     const j = l.indexOf("]", i + 1);
-    if (i >= 0 && j > i + 1) return { caption: l.slice(0, i).trim(), prompt: l.slice(i + 1, j).trim() };
+    if (i >= 0 && j > i + 1)
+      return {
+        caption: l.slice(0, i).trim(),
+        prompt: l.slice(i + 1, j).trim(),
+      };
     const line = l.trim();
     return { caption: line, prompt: line };
   });
@@ -240,7 +248,6 @@ async function run() {
     const t0 = performance.now();
     const card = cards[index];
     const body = card.querySelector(".card-body");
-    const dl = card.querySelector(".download-btn");
     setSpinner(card, true);
     try {
       const resp = await requestImage(fullPrompt, refs, opts);
@@ -250,8 +257,6 @@ async function run() {
       if (!b64) throw new Error("No image returned");
       const imgUrl = `data:image/${ui.format.value};base64,${b64}`;
       body.innerHTML = `<img src="${imgUrl}" title="${caption}" alt="${caption}" class="w-100 h-100 object-fit-cover">`;
-      dl.href = imgUrl;
-      dl.download = `${String(index + 1).padStart(3, "0")}-${slug(caption)}.${ui.format.value}`;
       times.push((performance.now() - t0) / 1000);
       index++;
       updateProgress(index, panels.length);

--- a/tools.json
+++ b/tools.json
@@ -50,6 +50,13 @@
       "created": "2025-07-22T00:00:00+00:00"
     },
     {
+      "icon": "bi-book",
+      "title": "PicBook",
+      "description": "Create a sequence of images from captions",
+      "url": "picbook",
+      "created": "2025-07-23T00:00:00+00:00"
+    },
+    {
       "icon": "bi-headset",
       "title": "SpeakMD",
       "description": "Turn Markdown into conversational text",


### PR DESCRIPTION
## Problem
Needed a way to generate a series of images from multiple captions while keeping a consistent style.

## Changes
- Added new **picbook** tool with HTML, JS and README
- Linked PicBook in `README.md` and `tools.json`
- Lint and format new files

## Review
- Code is contained in `picbook/` plus minor docs/metadata updates
- Look over the state machine logic and OpenAI API calls

## Verification
1. `npm run lint`
2. `npm test` *(fails: vitest not installed)*
3. Serve with `npx serve` and open `/picbook/`

## Risks
- Uses new dependencies (`saveform`, `bootstrap-llm-provider`, `jszip`)
- Requires valid OpenAI key and base URL

## Learnings
Combining saveform with openaiConfig simplifies persisting user choices across sessions.

------
https://chatgpt.com/codex/tasks/task_e_68864388e328832c84b4ead3842288d9