### PR TITLE
Enhance docs with OpenAI key guidance

### DIFF
--- a/githubsummary/README.md
+++ b/githubsummary/README.md
@@ -2,6 +2,8 @@
 
 This tool generates a blog-post-style summary of a GitHub user's activity within a specified date range.
 
+To use this tool you'll need an [OpenAI API key](https://platform.openai.com/account/api-keys). The key stays in your browser and is never stored on any server. Check [the code](script.js) to confirm. Straive employees can visit https://llmfoundry.straive.com/code for a token.
+
 ## Use Cases
 
 - **Track Contributions:** Quickly understand a developer's work and contributions over a period.

--- a/githubsummary/index.html
+++ b/githubsummary/index.html
@@ -50,9 +50,10 @@
                 </li>
               </ul>
               <p class="mb-0">
-                The app will fetch your GitHub events, repository details, and
-                commit information, then use AI to create a structured blog
-                post summary.
+              <p class="small text-muted mb-4">Generate an <a href="https://platform.openai.com/account/api-keys">OpenAI API key</a>. It stays in your browser and is never stored on a server. Inspect <a href="script.js">the code</a> or visit <a href="https://llmfoundry.straive.com/code">LLM Foundry</a> if you're a Straive employee.</p>
+              The app will fetch your GitHub events, repository details, and
+              commit information, then use AI to create a structured blog
+              post summary.
               </p>
             </div>
 

--- a/googlesuggest/index.html
+++ b/googlesuggest/index.html
@@ -117,6 +117,7 @@
     </header>
 
     <p class="lead mb-4">Enter a search term to see how Google auto-completes it across English-speaking countries (though your IP address location <em>does</em> influence this). You can also get an AI-powered humorous explanation of the results.</p>
+    <p class="small text-muted mb-4">Generate an <a href="https://platform.openai.com/account/api-keys">OpenAI API key</a>. It stays in your browser and is never stored on a server. Inspect <a href="script.js">the code</a> or visit <a href="https://llmfoundry.straive.com/code">LLM Foundry</a> if you're a Straive employee.</p>
     <form id="googlesuggest-form">
 
       <div class="row align-items-end mb-3">

--- a/imagegen/README.md
+++ b/imagegen/README.md
@@ -2,6 +2,8 @@
 
 Interactively generate and modify images using OpenAI's `gpt-image-1` model. Optionally upload an image or paste a URL, describe the changes you want, and chat to refine the result. A few sample images are loaded from `config.json` to try out the tool quickly.
 
+To use this tool you'll need an [OpenAI API key](https://platform.openai.com/account/api-keys). The key stays in your browser and is never stored on any server. Check [the code](script.js) to confirm. Straive employees can visit https://llmfoundry.straive.com/code for a token.
+
 ## What it does
 
 1. **Image Selection**

--- a/imagegen/index.html
+++ b/imagegen/index.html
@@ -24,6 +24,7 @@
         <div class="p-4 bg-white rounded-3 shadow-sm h-100">
           <h2 class="fs-4 mb-2">Create and modify images through conversation</h2>
           <p>Optionally upload an image or paste its URL, describe your changes, and keep chatting to iterate.</p>
+          <p class="small text-muted mb-4">Generate an <a href="https://platform.openai.com/account/api-keys">OpenAI API key</a>. It stays in your browser and is never stored on a server. Inspect <a href="script.js">the code</a> or visit <a href="https://llmfoundry.straive.com/code">LLM Foundry</a> if you're a Straive employee.</p>
           <ul class="list-unstyled mb-0">
             <li class="mb-2"><i class="bi bi-cloud-upload me-2 text-secondary"></i>Optionally upload or link to a starting image</li>
             <li class="mb-2"><i class="bi bi-pencil-square me-2 text-secondary"></i>Describe your changes and send</li>

--- a/picbook/README.md
+++ b/picbook/README.md
@@ -2,6 +2,18 @@
 
 PicBook turns a list of short captions into a sequence of images while keeping the style consistent. You can provide a reference image or URL as inspiration, add some context about the story and desired style, and then generate one panel per line.
 
+PicBook quickly generates a cohesive series of images from your captions. It certainly can produce comic books, but the same approach also works for:
+
+- marketing storyboards
+- product tour slides
+- training or onboarding modules
+- process documentation
+- consistent presentation graphics
+- personal comic strips
+
+To use the tool you'll need an [OpenAI API key](https://platform.openai.com/account/api-keys). Your key stays in your browser and is never sent anywhere. Check [the code](index.html) to verify. Straive employees can visit [LLM Foundry](https://llmfoundry.straive.com/code) for a token.
+
+
 ## What it does
 
 1. **Context and Panels**

--- a/picbook/index.html
+++ b/picbook/index.html
@@ -27,6 +27,7 @@
         page-break-before: avoid;
       }
     }
+
   </style>
 </head>
 
@@ -38,6 +39,16 @@
         <h1 class="display-5 fw-bold">PicBook</h1>
       </div>
     </header>
+    <p class="mb-3">PicBook quickly generates a cohesive series of images from your captions. It certainly creates comic books, but the same look is helpful for:</p>
+    <ul class="mb-3">
+      <li>marketing storyboards</li>
+      <li>product tour slides</li>
+      <li>training or onboarding modules</li>
+      <li>process documentation</li>
+      <li>consistent presentation graphics</li>
+      <li>personal comic strips</li>
+    </ul>
+    <p class="small text-muted mb-4">Generate an <a href="https://platform.openai.com/account/api-keys">OpenAI API key</a>; it stays in your browser and is never stored on a server. Inspect <a href="script.js">the code</a> or visit <a href="https://llmfoundry.straive.com/code">LLM Foundry</a> if you're a Straive employee.</p>
     <form id="picbook-form" class="bg-white rounded-3 shadow-sm p-3 mb-3">
       <div class="row g-3">
         <div class="col-lg-4">

--- a/podcast/README.md
+++ b/podcast/README.md
@@ -1,6 +1,8 @@
 # AI-Powered Podcast Generator
 
 This tool automates the creation of a two-person podcast episode, from script generation to audio synthesis, using Large Language Models (LLMs).
+To use this tool you'll need an [OpenAI API key](https://platform.openai.com/account/api-keys). The key stays in your browser and is never stored on any server. Check [the code](script.js) to confirm. Straive employees can visit https://llmfoundry.straive.com/code for a token.
+
 
 ## What it does
 

--- a/podcast/index.html
+++ b/podcast/index.html
@@ -32,6 +32,7 @@
           and get both a script and audio file.
         </p>
 
+        <p class="small text-muted mb-4">Generate an <a href="https://platform.openai.com/account/api-keys">OpenAI API key</a>. It stays in your browser and is never stored on a server. Inspect <a href="script.js">the code</a> or visit <a href="https://llmfoundry.straive.com/code">LLM Foundry</a> if you're a Straive employee.</p>
         <div class="row mt-4">
           <div class="col-md-4 mb-3">
             <div class="card h-100 border-0 shadow-sm">

--- a/speakmd/README.md
+++ b/speakmd/README.md
@@ -2,6 +2,7 @@
 
 SpeakMD converts Markdown into a conversational script that is easy to narrate aloud. It streams the conversion through a Large Language Model so you can watch the text appear in real time.
 
+To use this tool you'll need an [OpenAI API key](https://platform.openai.com/account/api-keys). The key stays in your browser and is never stored on any server. Check [the code](script.js) to confirm. Straive employees can visit [LLM Foundry](https://llmfoundry.straive.com/code) for a token.
 ## What it does
 
 1. **Paste Markdown:** Provide any Markdown text in the input box.

--- a/speakmd/index.html
+++ b/speakmd/index.html
@@ -24,6 +24,7 @@
     <p class="text-secondary">
       Convert Markdown into a friendly conversation for audio narration.
     </p>
+    <p class="small text-muted mb-4">Generate an <a href="https://platform.openai.com/account/api-keys">OpenAI API key</a>. It stays in your browser and is never stored on a server. Inspect <a href="script.js">the code</a> or visit <a href="https://llmfoundry.straive.com/code">LLM Foundry</a> if you're a Straive employee.</p>
     <form id="speakForm" class="mb-3">
       <div class="mb-3">
         <label for="markdownInput" class="form-label">Markdown</label>


### PR DESCRIPTION
## Summary
- explain PicBook in detail with business-focused examples
- add OpenAI API key instructions across Bootstrap LLM tools

## Testing
- `npx -y prettier@3.5 --print-width=120 '**/*.js' '**/*.md'`
- `npx -y js-beautify@1 '**/*.html' --type html --replace --indent-size 2 --max-preserve-newlines 1 --end-with-newline`
- `uvx ruff check --line-length 100 .`


------
https://chatgpt.com/codex/tasks/task_e_6886dd2e4524832cb6f5160c9acf1339