### PR TITLE
Add comparator tool

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,6 +20,7 @@ A collection of single page web apps, mostly LLM generated. Hosted at [tools.s-a
 - **[Straive Intelligence](./straiveintelligence/)**: Bookmarklet to convert ChatGPT into a Straive-style user interface
 - **[GitHub Summary](./githubsummary/)**: Generates a blog-post-style summary of a GitHub user's activity within a specified date range.
 - **[Join CSV Tables](./joincsv/)**: Join multiple tables on the first column.
+- **[Comparator](./comparator/)**: Highlight differences between ground truth and system output using LLM.
 - **[Google Suggest Explorer](./googlesuggest/)**: Explore Google Search suggestions from different countries and get AI-powered humorous explanations.
 - **[GitHub Users](./githubusers/)**: A web-based tool that allows you to fetch publicly available information for specified GitHub users.
 - **[Unicode](./unicode/)**: Helps users identify, view, and copy non-ASCII Unicode characters present in a given text, showing their hexadecimal and decimal code points.

--- a/comparator/index.html
+++ b/comparator/index.html
@@ -1,0 +1,73 @@
+<!doctype html>
+<html lang="en">
+
+<head>
+  <meta charset="UTF-8" />
+  <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+  <title>Comparator</title>
+  <link rel="icon" type="image/svg+xml" href="data:image/svg+xml;base64,PHN2ZyB4bWxucz0iaHR0cDovL3d3dy53My5vcmcvMjAwMC9zdmciIHZpZXdCb3g9IjAgMCAzMiAzMiI+PGNpcmNsZSBjeD0iMTYiIGN5PSIxNiIgcj0iMTUiIGZpbGw9IiMyNTYzZWIiLz48cGF0aCBmaWxsPSIjZmZmIiBkPSJtMTYgNyAyIDcgNyAyLTcgMi0yIDctMi03LTctMiA3LTJaIi8+PC9zdmc+" />
+  <link href="https://cdn.jsdelivr.net/npm/bootstrap@5.3.6/dist/css/bootstrap.min.css" rel="stylesheet" crossorigin="anonymous" />
+  <link href="https://cdn.jsdelivr.net/npm/bootstrap-icons@1.13.1/font/bootstrap-icons.css" rel="stylesheet" crossorigin="anonymous" />
+  <style>
+    .sticky-header {
+      position: sticky;
+      top: 0;
+      background: var(--bs-body-bg);
+      z-index: 1
+    }
+
+    .sticky-col {
+      position: sticky;
+      left: 0;
+      background: var(--bs-body-bg);
+      z-index: 1
+    }
+
+    td {
+      cursor: pointer
+    }
+
+  </style>
+</head>
+
+<body>
+  <div class="container my-5" id="app">
+    <h1 class="mb-4">Comparator</h1>
+    <form id="comparator-form">
+      <div class="row g-3 mb-3">
+        <div class="col-md-6">
+          <label for="input-box" class="form-label">Input (Ground Truth)</label>
+          <textarea id="input-box" class="form-control font-monospace" rows="16" cols="100"></textarea>
+        </div>
+        <div class="col-md-6">
+          <label for="output-box" class="form-label">Output (System Result)</label>
+          <textarea id="output-box" class="form-control font-monospace" rows="16" cols="100"></textarea>
+        </div>
+      </div>
+      <button type="button" id="run-btn" class="btn btn-primary"><i class="bi bi-play-fill"></i> Run</button>
+      <button type="button" id="openai-config-btn" class="btn btn-secondary ms-2"><i class="bi bi-key"></i> API</button>
+    </form>
+    <div id="progress" class="progress my-3 d-none">
+      <div id="progress-bar" class="progress-bar" role="progressbar" style="width:0%"></div>
+    </div>
+    <div id="results" class="table-responsive"></div>
+  </div>
+
+  <div class="modal fade" id="detail-modal" tabindex="-1" aria-hidden="true">
+    <div class="modal-dialog">
+      <div class="modal-content">
+        <div class="modal-header">
+          <h5 class="modal-title">Details</h5>
+          <button type="button" class="btn-close" data-bs-dismiss="modal" aria-label="Close"></button>
+        </div>
+        <div class="modal-body"></div>
+      </div>
+    </div>
+  </div>
+
+  <script src="https://cdn.jsdelivr.net/npm/bootstrap@5.3.6/dist/js/bootstrap.bundle.min.js" crossorigin="anonymous"></script>
+  <script src="https://cdn.jsdelivr.net/npm/bootstrap-dark-theme@1" type="module"></script>
+  <script type="module" src="script.js"></script>
+</body>
+
+</html>

--- a/comparator/script.js
+++ b/comparator/script.js
@@ -1,0 +1,200 @@
+import { dsvFormat } from "https://cdn.jsdelivr.net/npm/d3-dsv@3/+esm";
+import TurndownService from "https://cdn.jsdelivr.net/npm/turndown@7/+esm";
+import { gfm } from "https://cdn.jsdelivr.net/npm/@joplin/turndown-plugin-gfm@1/+esm";
+import { bootstrapAlert } from "https://cdn.jsdelivr.net/npm/bootstrap-alert@1";
+import { openaiConfig } from "https://cdn.jsdelivr.net/npm/bootstrap-llm-provider@1";
+import { openaiHelp } from "../common/aiconfig.js";
+import saveform from "https://cdn.jsdelivr.net/npm/saveform@1.2";
+
+const DEFAULT_BASE_URLS = [
+  "https://api.openai.com/v1",
+  "https://aipipe.org/openai/v1",
+  "https://llmfoundry.straive.com/openai/v1",
+];
+
+const ui = {
+  input: document.getElementById("input-box"),
+  output: document.getElementById("output-box"),
+  run: document.getElementById("run-btn"),
+  progress: document.getElementById("progress"),
+  bar: document.getElementById("progress-bar"),
+  results: document.getElementById("results"),
+  config: document.getElementById("openai-config-btn"),
+  modal: new bootstrap.Modal(document.getElementById("detail-modal")),
+  modalBody: document.querySelector("#detail-modal .modal-body"),
+};
+
+saveform("#comparator-form", { exclude: '[type="file"]' });
+
+let promptTemplate = "";
+fetch("../prompts/comparator.md")
+  .then((r) => r.text())
+  .then((t) => (promptTemplate = t));
+
+const dsv = dsvFormat("\t");
+const turndown = new TurndownService();
+turndown.use(gfm);
+
+function parseTSV(text) {
+  const clean = text
+    .replace(/^\uFEFF/, "")
+    .replace(/\r\n/g, "\n")
+    .trim();
+  if (!clean) return { headers: [], rows: [] };
+  const data = dsv.parse(clean);
+  const headers = data.columns;
+  const rows = data.map((r) => {
+    const obj = {};
+    headers.forEach((h) => {
+      const v = (r[h] || "").trim();
+      obj[h] = v ? v : null;
+    });
+    return obj;
+  });
+  return { headers, rows };
+}
+
+const evalKeys = (headers) => {
+  const start = headers.indexOf("Name");
+  const end = headers.indexOf("Notes");
+  return headers.slice(start, end === -1 ? headers.length : end);
+};
+
+function baseline(a, b, keys) {
+  const res = {};
+  keys.forEach((k) => {
+    const x = (a[k] || "").trim().toLowerCase();
+    const y = (b[k] || "").trim().toLowerCase();
+    res[k] = x === y ? "match" : "mismatch";
+  });
+  return res;
+}
+
+async function fetchMarkdown(url) {
+  const r = await fetch(`https://llmfoundry.straive.com/-/proxy/${url}`);
+  return turndown.turndown(await r.text());
+}
+
+async function llm(markdown, extract, apiKey, baseUrl) {
+  const body = (m) =>
+    JSON.stringify({
+      model: "gpt-4o",
+      messages: [{ role: "system", content: m }],
+      temperature: 0,
+    });
+  let attempt = 0;
+  while (attempt < 2) {
+    const msg = promptTemplate.replace("{{MARKDOWN}}", markdown).replace("{{JSON}}", JSON.stringify(extract));
+    const resp = await fetch(`${baseUrl}/chat/completions`, {
+      method: "POST",
+      headers: { "Content-Type": "application/json", Authorization: `Bearer ${apiKey}` },
+      body: body(msg),
+    });
+    const data = await resp.json();
+    try {
+      return JSON.parse(data.choices[0].message.content);
+    } catch {
+      attempt += 1;
+    }
+  }
+  throw new Error("Invalid LLM response");
+}
+
+function updateProgress(i, total, start, latSum) {
+  const pct = Math.round((i / total) * 100);
+  ui.bar.style.width = `${pct}%`;
+  ui.bar.textContent = `${pct}%`;
+  const rowsPerSec = (i / ((Date.now() - start) / 1000)).toFixed(2);
+  const latency = i ? (latSum / i).toFixed(0) : 0;
+  ui.bar.title = `${rowsPerSec} rows/s, ${latency}ms`;
+}
+
+function render(results, keys) {
+  const colRed = Object.fromEntries(keys.map((k) => [k, 0]));
+  let totalRed = 0;
+  let html = '<table class="table table-bordered table-sm m-3">';
+  html += '<thead><tr><th class="sticky-header sticky-col">#</th>';
+  keys.forEach((k) => (html += `<th class="sticky-header">${k}</th>`));
+  html += '<th class="sticky-header">Row Error %</th></tr></thead><tbody>';
+  results.forEach((r, i) => {
+    let rowRed = 0;
+    html += `<tr><th class="sticky-col">${i + 1}</th>`;
+    keys.forEach((k) => {
+      const verdict = r.llm.results[k]?.status === "correct" ? "match" : "mismatch";
+      const ok = verdict === r.base[k];
+      if (!ok) {
+        rowRed += 1;
+        colRed[k] += 1;
+        totalRed += 1;
+      }
+      const cls = ok ? "table-success" : "table-danger";
+      html += `<td data-row="${i}" data-key="${k}" class="${cls}">${verdict}</td>`;
+    });
+    html += `<td>${Math.round((rowRed / keys.length) * 100)}</td></tr>`;
+  });
+  html += '</tbody><tfoot><tr><th class="sticky-col">Col Error %</th>';
+  keys.forEach((k) => {
+    html += `<th>${Math.round((colRed[k] / results.length) * 100)}</th>`;
+  });
+  html += `<th>${Math.round((totalRed / (results.length * keys.length)) * 100)}</th></tr></tfoot></table>`;
+  ui.results.innerHTML = html;
+}
+
+ui.results.addEventListener("click", (e) => {
+  const td = e.target.closest("td[data-row]");
+  if (!td) return;
+  const r = window.__rows[+td.dataset.row];
+  const key = td.dataset.key;
+  const j = JSON.stringify(r.llm.results[key], null, 2);
+  const body = `<p><strong>Input:</strong> ${r.input[key] || ""}</p><p><strong>Output:</strong> ${
+    r.output[key] || ""
+  }</p><pre>${j}</pre>`;
+  ui.modalBody.innerHTML = body;
+  ui.modal.show();
+});
+
+ui.config.addEventListener("click", async () => {
+  await openaiConfig({ defaultBaseUrls: DEFAULT_BASE_URLS, show: true, help: openaiHelp });
+});
+
+ui.run.addEventListener("click", async () => {
+  const { apiKey, baseUrl } = await openaiConfig({ defaultBaseUrls: DEFAULT_BASE_URLS, help: openaiHelp });
+  if (!apiKey) return;
+  const inData = parseTSV(ui.input.value);
+  const outData = parseTSV(ui.output.value);
+  if (!inData.rows.length || !outData.rows.length) {
+    bootstrapAlert({ title: "Input needed", body: "Both tables required", color: "danger" });
+    return;
+  }
+  if (inData.headers.join() !== outData.headers.join()) {
+    bootstrapAlert({ title: "Header mismatch", body: "Input and Output headers differ", color: "danger" });
+    return;
+  }
+  const keys = evalKeys(inData.headers);
+  const total = inData.rows.length;
+  let latSum = 0;
+  const start = Date.now();
+  const results = [];
+  ui.progress.classList.remove("d-none");
+  for (let i = 0; i < total; i++) {
+    updateProgress(i, total, start, latSum);
+    const inputRow = inData.rows[i];
+    const outputRow = outData.rows[i];
+    const base = baseline(inputRow, outputRow, keys);
+    const md = await fetchMarkdown(inputRow.FacultySource);
+    const extract = Object.fromEntries(keys.map((k) => [k, inputRow[k]]));
+    const t0 = performance.now();
+    let llmRes;
+    try {
+      llmRes = await llm(md, extract, apiKey, baseUrl);
+    } catch (err) {
+      bootstrapAlert({ title: "LLM error", body: err.message, color: "danger" });
+      return;
+    }
+    latSum += performance.now() - t0;
+    results.push({ input: inputRow, output: outputRow, base, llm: llmRes });
+  }
+  updateProgress(total, total, start, latSum);
+  window.__rows = results;
+  render(results, keys);
+});

--- a/prompts/comparator.md
+++ b/prompts/comparator.md
@@ -1,0 +1,42 @@
+# GOAL
+
+For every original key in EXTRACT_JSON:
+
+- If both sources (Markdown and JSON) have the same semantic value → "correct".
+- If both sources (Markdown and JSON) have no value (null, empty, None or not mentioned) → "correct".
+- If both sources (Markdown and JSON) have different semantic values → "incorrect".
+- If one source has a value and the other does not (null, empty, None or not mentioned) → "incorrect".
+
+# DEFINITIONS
+
+"No value" = null, empty string, empty array/object, or None or NOT MENTIONED in WEBSITE_MD.
+"Same semantic value" = equal after normalizing case, whitespace, punctuation, trivial formatting; numbers equal within rounding; dates same after normalization (ISO-8601). Otherwise, treat as different.
+
+# THINK (silently)
+
+1. Parse EXTRACT_JSON. Flatten nested keys with dot-paths (e.g., "address.city").
+2. Search WEBSITE_MD for each key’s concept/value.
+3. Decide status per rules above.
+4. Build output exactly matching SCHEMA.
+
+# OUTPUT
+
+Return **valid JSON** that conforms to SCHEMA. No extra text.
+
+<SCHEMA>
+"results": {
+  "<dot_key>": {"status": "correct" | "incorrect", "json_value": any, "markdown_value": string | null}
+  // ...one object per key from EXTRACT_JSON
+}
+</SCHEMA>
+
+# INPUTS
+
+<WEBSITE_MD>
+{{MARKDOWN}}
+</WEBSITE_MD>
+
+<EXTRACT_JSON>
+{{JSON}}
+</EXTRACT_JSON>
+</prompt>

--- a/tools.json
+++ b/tools.json
@@ -98,6 +98,13 @@
       "created": "2025-06-10T09:38:18+00:00"
     },
     {
+      "icon": "bi-check2",
+      "title": "Comparator",
+      "description": "Highlight differences between ground truth and system output using LLM.",
+      "url": "comparator",
+      "created": "2025-08-30T00:00:00+00:00"
+    },
+    {
       "icon": "bi-search-heart",
       "title": "Google Suggest Explorer",
       "description": "Explore Google Search suggestions from different countries and get AI-powered humorous explanations.",


### PR DESCRIPTION
## Summary
- create comparator webapp with two TSV textareas and results table
- fetch web pages via LLM Foundry proxy and compare results with an LLM
- add locked prompt for LLM comparison
- document new tool in README and tools.json

## Testing
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_688883f551a8832c94ce3862cb65711d