### PR TITLE
feat: split event fetching from summary

### DIFF
--- a/githubsummary/index.html
+++ b/githubsummary/index.html
@@ -210,9 +210,18 @@ Make it engaging and easy to follow just by listening.</textarea>
                 </div>
               </div>
 
-              <button type="submit" class="btn btn-primary btn-lg w-100">
-                Generate Summary
-              </button>
+              <div class="row mb-3">
+                <div class="col-md-6">
+                  <button id="get-events-btn" type="button" class="btn btn-primary w-100">
+                    Get events
+                  </button>
+                </div>
+                <div class="col-md-6">
+                  <button id="generate-summary-btn" type="button" class="btn btn-primary w-100" disabled>
+                    Generate Summary
+                  </button>
+                </div>
+              </div>
             </form>
 
             <div id="progress-section" class="mt-4" style="display: none">
@@ -232,6 +241,7 @@ Make it engaging and easy to follow just by listening.</textarea>
               <h5>Summary</h5>
               <div id="results-content" class="border rounded p-3 bg-white"></div>
             </div>
+            <div id="events-table" class="mt-4 table-responsive" style="display: none"></div>
           </div>
         </div>
       </div>


### PR DESCRIPTION
### Problem
- Users couldn't inspect GitHub events before generating summaries.

### Changes
- Added two-step flow with **Get events** and **Generate Summary** buttons.
- Rendered fetched events in a table appended after the summary section.
- Refactored JS to store fetched data and enable the summary step only after events load.
- Restored explanatory comments in `githubsummary/script.js` for clarity.

### Review Notes
- Focus on new DOM event handlers and restored comments in `githubsummary/script.js`.
- HTML structure follows existing Bootstrap conventions and remains low-risk.

### Verification
1. `npm run lint`
2. `npm test` *(no tests found; exits with code 1)*
3. `npx playwright install chromium`
4. `npx playwright install-deps`
5. `npm run screenshot -- githubsummary/ githubsummary/screenshot.webp`
6. Open `githubsummary/index.html` in a browser, fetch events, then generate summary.

### Deployment Risks
- Minimal; changes are client-side only. Ensure Playwright deps exist for screenshots.

### Developer Notes
- Demonstrates splitting complex UI flows into sequential steps and maintaining inline documentation for readability.


------
https://chatgpt.com/codex/tasks/task_e_688e38de66e4832cb7e25f1c33d3eba3