### PR TITLE
feat(githubsummary): preview events before summary

### DIFF
--- a/githubsummary/index.html
+++ b/githubsummary/index.html
@@ -210,7 +210,10 @@ Make it engaging and easy to follow just by listening.</textarea>
                 </div>
               </div>
 
-              <button type="submit" class="btn btn-primary btn-lg w-100">
+              <button id="get-events-btn" type="button" class="btn btn-secondary btn-lg w-100 mb-3">
+                Get events
+              </button>
+              <button id="generate-summary-btn" type="button" class="btn btn-primary btn-lg w-100" disabled>
                 Generate Summary
               </button>
             </form>
@@ -231,6 +234,11 @@ Make it engaging and easy to follow just by listening.</textarea>
             <div id="results-section" class="mt-4" style="display: none">
               <h5>Summary</h5>
               <div id="results-content" class="border rounded p-3 bg-white"></div>
+            </div>
+
+            <div id="events-section" class="mt-4" style="display: none">
+              <h5>Events</h5>
+              <div id="events-table"></div>
             </div>
           </div>
         </div>


### PR DESCRIPTION
## Problem
Single-step summary generation hid raw events and offered no preview.

## Changes
- split workflow into **Get events** and **Generate Summary** buttons
- stream GitHub events into a live table with lit-html
- reuse fetched events when generating the AI summary

## Review Notes
- UI layout in `githubsummary/index.html` is straightforward
- Inspect event-table rendering and fetch flow in `githubsummary/script.js`

## Verification
1. `npm run lint`
2. `npm test -- githubsummary/test.js` *(expects no tests)*
3. Open `githubsummary/index.html`
4. Enter a user and dates → **Get events**
5. Review events table, then **Generate Summary**

## Risks & Mitigations
- Additional GitHub API calls: mitigated by existing caching
- Large event lists: table renders incrementally to avoid blocking

## Learnings
- Demonstrates progressive enhancement with lit-html and staged API requests.

------
https://chatgpt.com/codex/tasks/task_e_688e4298ce7c832c9224dfe72e9514d1