### PR TITLE
feat(picbook): add reference switches

### DIFF
--- a/picbook/README.md
+++ b/picbook/README.md
@@ -10,8 +10,8 @@ PicBook turns a list of short captions into a sequence of images while keeping t
    - Enter common guidance for the whole book.
    - Each line is `Caption text [Prompt for LLM]`.
 2. **Reference Image**
-   - Optionally upload or link to an image so the first panel matches its style.
-   - Later panels use both the original reference and the previous image.
+   - Optionally upload or link to an image; the first panel always uses it.
+   - Switches decide if later panels reuse this image and/or the previous panel.
 3. **Progress Tracking**
    - A progress bar shows how many panels are done and estimates total time.
    - You can pause after any panel and continue later.
@@ -21,6 +21,6 @@ PicBook turns a list of short captions into a sequence of images while keeping t
 ## How it works
 
 1. Configure your OpenAI API key and base URL.
-2. The first panel uses the uploaded image (or URL) if provided.
-3. Later panels also send the previous image for style consistency.
+2. If an image or URL is provided, the first panel always uses it.
+3. Switches control reuse of the base image and the previous panel for later prompts.
 4. Images appear as soon as they are ready and can be saved individually or as a ZIP.

--- a/picbook/index.html
+++ b/picbook/index.html
@@ -85,6 +85,15 @@
             <input id="background" type="checkbox" class="form-check-input" />
             <label class="form-check-label" for="background">Transparent background</label>
           </div>
+          <div class="form-check form-switch mb-3">
+            <input id="use-prev" type="checkbox" class="form-check-input" checked />
+            <label class="form-check-label" for="use-prev">Use previous panel</label>
+          </div>
+          <div class="form-check form-switch mb-3">
+            <input id="keep-base" type="checkbox" class="form-check-input" checked />
+            <label class="form-check-label" for="keep-base">Reuse reference image</label>
+            <div class="form-text">First panel always uses it if supplied</div>
+          </div>
         </div>
         <div class="col-lg-8">
           <label for="panels" class="form-label">Panels</label>

--- a/picbook/script.js
+++ b/picbook/script.js
@@ -33,6 +33,8 @@ const ui = {
   format: document.getElementById("output-format"),
   compression: document.getElementById("output-compression"),
   background: document.getElementById("background"),
+  usePrev: document.getElementById("use-prev"),
+  keepBase: document.getElementById("keep-base"),
 };
 
 ui.configBtn.addEventListener("click", async () => {
@@ -240,9 +242,9 @@ async function run() {
   while (index < panels.length && state === "running") {
     const { caption, prompt } = panels[index];
     const refs = [];
-    if (baseFile) refs.push(URL.createObjectURL(baseFile));
-    else if (baseUrl) refs.push(baseUrl);
-    if (index) refs.push(cards[index - 1].querySelector("img")?.src);
+    if (baseFile && (ui.keepBase.checked || index === 0)) refs.push(URL.createObjectURL(baseFile));
+    else if (baseUrl && (ui.keepBase.checked || index === 0)) refs.push(baseUrl);
+    if (index && ui.usePrev.checked) refs.push(cards[index - 1].querySelector("img")?.src);
     const fullPrompt = ctx ? `${ctx} ${prompt}` : prompt;
     const t0 = performance.now();
     const card = cards[index];


### PR DESCRIPTION
## Problem
PicBook always forwarded both the initial reference and previous panel to every panel, giving users no control.

## Changes
- add UI switches to control reuse of the reference image and previous panel (`picbook/index.html`)
- pass references based on switch values, always including the first panel if provided (`picbook/script.js`)
- document the new options and behavior (`picbook/README.md`)

## Review
- ensure the reference logic in `run()` handles all combinations safely
- UI text and defaults should feel intuitive; check for styling issues

## Verification
1. `npm run lint`
2. `npm test` (expect "No test files found")
3. Open `picbook/index.html`, toggle switches, and generate panels

## Deployment
- Defaults preserve prior behavior; minimal risk
- If new switches misbehave, users can leave them enabled for old behavior

## Learning
Explicit switches clarify how reference images propagate, simplifying future feature additions and user control.


------
https://chatgpt.com/codex/tasks/task_e_6892aa00679c832cbe31a41eabea441e