### PR TITLE
feat: add image data extractor tool

### DIFF
--- a/dataextractor/README.md
+++ b/dataextractor/README.md
@@ -1,0 +1,9 @@
+# Data Extractor
+
+Extract chart or table data from images into CSV using OpenAI vision.
+
+## Usage
+
+1. Configure the OpenAI API key via **Config**.
+2. Upload a chart or table image.
+3. Click **Extract** to view and download the CSV.

--- a/dataextractor/config.json
+++ b/dataextractor/config.json
@@ -1,0 +1,7 @@
+{
+  "defaultBaseUrls": [
+    "https://api.openai.com/v1",
+    "https://llmfoundry.straivedemo.com/openai/v1",
+    "https://llmfoundry.straive.com/openai/v1"
+  ]
+}

--- a/dataextractor/index.html
+++ b/dataextractor/index.html
@@ -1,0 +1,44 @@
+<!doctype html>
+<html lang="en">
+
+<head>
+  <meta charset="UTF-8" />
+  <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+  <title>Data Extractor</title>
+  <link rel="icon" type="image/svg+xml" href="data:image/svg+xml;base64,PHN2ZyB4bWxucz0iaHR0cDovL3d3dy53My5vcmcvMjAwMC9zdmciIHZpZXdCb3g9IjAgMCAzMiAzMiI+PGNpcmNsZSBjeD0iMTYiIGN5PSIxNiIgcj0iMTUiIGZpbGw9IiMyNTYzZWIiLz48cGF0aCBmaWxsPSIjZmZmIiBkPSJtMTYgNyAyIDcgNyAyLTcgMi0yIDctMi03LTctMiA3LTJaIi8+PC9zdmc+" />
+  <link href="https://cdn.jsdelivr.net/npm/bootstrap@5.3.6/dist/css/bootstrap.min.css" rel="stylesheet" crossorigin="anonymous" />
+  <link href="https://cdn.jsdelivr.net/npm/bootstrap-icons@1.13.1/font/bootstrap-icons.css" rel="stylesheet" crossorigin="anonymous" />
+</head>
+
+<body>
+  <nav class="navbar navbar-expand-lg bg-body-tertiary mb-4">
+    <div class="container">
+      <a class="navbar-brand d-flex align-items-center" href="../">
+        <i class="bi bi-table me-2"></i>
+        Data Extractor
+      </a>
+      <div class="bootstrap-dark-theme"></div>
+    </div>
+  </nav>
+  <div class="container">
+    <form id="dataextractor-form" class="mb-3">
+      <div class="mb-3">
+        <input id="image-input" type="file" accept="image/*" class="form-control" />
+      </div>
+      <div class="d-flex gap-2">
+        <button type="submit" class="btn btn-primary flex-grow-1">Extract</button>
+        <button type="button" id="openai-config-btn" class="btn btn-outline-secondary">Config</button>
+      </div>
+    </form>
+    <div id="loading" class="d-none mb-3 text-center">
+      <div class="spinner-border" role="status"><span class="visually-hidden">Loading...</span></div>
+    </div>
+    <div id="output" class="mb-3"></div>
+    <button id="download-btn" class="btn btn-success d-none"><i class="bi bi-download"></i> Download CSV</button>
+  </div>
+  <script src="https://cdn.jsdelivr.net/npm/bootstrap@5.3.6/dist/js/bootstrap.bundle.min.js" crossorigin="anonymous"></script>
+  <script src="https://cdn.jsdelivr.net/npm/bootstrap-dark-theme@1" type="module"></script>
+  <script type="module" src="script.js"></script>
+</body>
+
+</html>

--- a/dataextractor/script.js
+++ b/dataextractor/script.js
@@ -1,0 +1,97 @@
+import { openaiConfig } from "https://cdn.jsdelivr.net/npm/bootstrap-llm-provider@1";
+import { openaiHelp } from "../common/aiconfig.js";
+import { bootstrapAlert } from "https://cdn.jsdelivr.net/npm/bootstrap-alert@1";
+import { objectsToCsv, csvToTable, downloadCsv } from "../common/csv.js";
+
+const qs = (id) => document.getElementById(id);
+const ui = {
+  form: qs("dataextractor-form"),
+  file: qs("image-input"),
+  out: qs("output"),
+  loading: qs("loading"),
+  configBtn: qs("openai-config-btn"),
+  download: qs("download-btn"),
+};
+
+let config = { defaultBaseUrls: [] };
+fetch("config.json")
+  .then((r) => r.json())
+  .then((c) => (config = c));
+
+ui.configBtn.addEventListener("click", async () => {
+  await openaiConfig({ defaultBaseUrls: config.defaultBaseUrls, show: true, help: openaiHelp });
+});
+
+ui.form.addEventListener("submit", extract);
+
+const cols = ["company", "date", "period", "fact", "value", "units", "comments"];
+const prompt = () =>
+  `From the image extract rows of {${cols.join(",")}}. Company from context or "unknown". Unknown fields empty. Return {"data": [...]}.`;
+const fields = () => cols.reduce((o, k) => ((o[k] = { type: "string" }), o), {});
+
+async function extract(e) {
+  e.preventDefault();
+  const file = ui.file.files[0];
+  if (!file) return bootstrapAlert({ title: "Image missing", body: "Upload an image", color: "warning" });
+
+  const { apiKey, baseUrl } = await openaiConfig({ defaultBaseUrls: config.defaultBaseUrls, help: openaiHelp });
+  if (!apiKey) return bootstrapAlert({ title: "API key", body: "Configure OpenAI key", color: "warning" });
+
+  ui.loading.classList.remove("d-none");
+  ui.out.innerHTML = "";
+  ui.download.classList.add("d-none");
+
+  const dataUrl = await fileToDataUrl(file);
+  const { asyncLLM } = await import("https://cdn.jsdelivr.net/npm/asyncllm@2");
+
+  let text = "";
+  const schema = {
+    type: "object",
+    properties: { data: { type: "array", items: { type: "object", properties: fields(), required: cols } } },
+    required: ["data"],
+  };
+  for await (const { content, error } of asyncLLM(`${baseUrl}/chat/completions`, {
+    method: "POST",
+    headers: { "Content-Type": "application/json", Authorization: `Bearer ${apiKey}` },
+    body: JSON.stringify({
+      model: "gpt-4o-mini",
+      stream: true,
+      messages: [
+        {
+          role: "user",
+          content: [
+            { type: "input_text", text: prompt() },
+            { type: "input_image", image_url: { url: dataUrl } },
+          ],
+        },
+      ],
+      response_format: { type: "json_schema", json_schema: { name: "dataextractor", schema } },
+    }),
+  })) {
+    if (error) return done(`API error: ${error}`);
+    text = content ?? "";
+  }
+
+  try {
+    const data = JSON.parse(text).data;
+    const csv = objectsToCsv(data);
+    csvToTable(ui.out, csv);
+    ui.download.onclick = () => downloadCsv(csv, "data.csv");
+    ui.download.classList.remove("d-none");
+  } catch {
+    return done("Bad JSON from model");
+  }
+  done();
+}
+
+const fileToDataUrl = (f) =>
+  new Promise((res) => {
+    const r = new FileReader();
+    r.onload = () => res(r.result);
+    r.readAsDataURL(f);
+  });
+
+function done(msg) {
+  ui.loading.classList.add("d-none");
+  if (msg) bootstrapAlert({ title: "Error", body: msg, color: "danger" });
+}

--- a/tools.json
+++ b/tools.json
@@ -238,6 +238,13 @@
       "created": "2024-11-02T00:01:59+08:00"
     },
     {
+      "icon": "bi-table",
+      "title": "Data Extractor",
+      "description": "Extract chart and table data from images into CSV.",
+      "url": "dataextractor",
+      "created": "2025-08-06T03:54:17+00:00"
+    },
+    {
       "icon": "bi-markdown-fill",
       "title": "Render Markdown",
       "description": "Render Markdown to HTML using the GitHub Markdown API.",


### PR DESCRIPTION
## Problem
- Need a web tool to turn chart or table images into structured CSV data.

## Changes
- `dataextractor/index.html`, `dataextractor/script.js`: new Data Extractor tool for uploading an image, sending it to OpenAI, and downloading extracted data as CSV.
- `dataextractor/config.json`, `dataextractor/README.md`: configuration and usage docs.
- `tools.json`: register Data Extractor tool.

## Review
- Low risk: HTML layout, README.
- Medium risk: OpenAI request/JSON parsing in `script.js`.

## Verification
- `npx -y prettier@3.5 --print-width=120 --write dataextractor/script.js dataextractor/README.md dataextractor/config.json tools.json`
- `npx -y js-beautify@1 'dataextractor/*.html' --type html --replace --indent-size 2 --max-preserve-newlines 1 --end-with-newline`
- `npm test` *(fails: No test files found)*
- `npx playwright install`
- `npm run screenshot -- dataextractor dataextractor/screenshot.webp`

## Deployment
- Requires OpenAI-compatible API key configured by users.
- No server-side changes; static assets only.

## Lessons
- Demonstrates using `asyncLLM` with image inputs and JSON schema to extract structured data from charts and tables.

------
https://chatgpt.com/codex/tasks/task_e_6892d110fe70832c84c01b6fab27d3a7