### PR TITLE
feat(googletasks): persist refresh token and show user

### DIFF
--- a/googletasks/README.md
+++ b/googletasks/README.md
@@ -14,4 +14,4 @@ It also lets you copy the results straight into Excel or Markdown, and delete al
 5. Sub-tasks show up as bullet points in the notes of their parent tasks.
 6. Markdown exports keep line breaks and nested bullets from the notes.
 
-Your access token is stored locally in your browser using `saveform`.
+Your refresh token and email are saved together in localStorage (key: `googletasks`) so you stay signed in and see your address on the Sign in button.


### PR DESCRIPTION
## Problem
Auth info for Google Tasks was stored across multiple localStorage keys and relied on duplicated token exchange code.

## Changes
- consolidate refresh token and email into one `googletasks` localStorage entry (`googletasks/script.js`)
- refactor OAuth token exchange and refresh into a shared helper (`googletasks/script.js`)
- document consolidated storage (`googletasks/README.md`)

## Review
- Review sign-in/refresh logic in `script.js`; README change is informational.
- Token persistence and retrieval deserve extra scrutiny; other changes are low risk.

## Verification
1. `npm run lint`
2. `npm test -- googletasks/test.js` *(fails: No test files found)*

## Deployment
- Risk: stale or invalid JSON in `localStorage`; mitigation: sign-out clears the `googletasks` key.

## Learning
- Shows how consolidating auth state and DRYing OAuth requests simplifies persistent sign-in flows.


------
https://chatgpt.com/codex/tasks/task_e_6892eea96b24832cb4ebb2d706b5266c