### PR TITLE
Add tests for data and GitHub tools

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -47,8 +47,9 @@ Common layout: each tool has `index.html` linking Bootstrap 5, bootstrap-icons@1
 - Drive UI through real DOM events. `element.click()` / `dispatchEvent(new window.Event("input",{bubbles:true}))` instead of directly calling handlers; matches user behaviour.
 - Add timeouts per test case, e.g. `{ timeout: 10_000 }`, for long-running tests.
 
-### Running tests offline
+### Running tests
 
-- Mirror CDN assets under `vendor/` with the same paths used in HTML and scripts.
-  - bootstrap@5.3.6 (CSS/JS), bootstrap-icons@1.13.1 (CSS/fonts), bootstrap-alert@1, saveform@1.2, marked@4.3.0, d3-dsv@3/+esm, pages for `news.ycombinator.com` and `www.hntoplinks.com/week`.
-- Extend `common/testutils.js` `virtualServers` with `https://cdn.jsdelivr.net/` and `https://llmfoundry.straive.com/` pointing to those mirrors.
+- Tests fetch CDN assets. Before running tests, mirror them under `vendor/` with the same paths used in HTML and scripts. E.g. `curl -L https://cdn.jsdelivr.net/npm/bootstrap@5.3.6/dist/css/bootstrap.min.css -o vendor/npm/bootstrap@5.3.6/dist/css/bootstrap.min.css`
+  - Mirror bootstrap@5.3.6 (CSS/JS), bootstrap-icons@1.13.1 (CSS/fonts), bootstrap-alert@1, saveform@1.2, marked@4.3.0, d3-dsv@3/+esm
+  - Mirror pages for `news.ycombinator.com`, `www.hntoplinks.com/week`, etc.
+- Extend `common/testutils.js` `virtualServers` with `https://cdn.jsdelivr.net/`, `https://news.ycombinator.com/`, etc. pointing to those mirrors.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -46,3 +46,9 @@ Common layout: each tool has `index.html` linking Bootstrap 5, bootstrap-icons@1
 - Build specialised browsers (`new Browser({device:{prefersColorScheme:"dark"}})`) to test colour-scheme logic.
 - Drive UI through real DOM events. `element.click()` / `dispatchEvent(new window.Event("input",{bubbles:true}))` instead of directly calling handlers; matches user behaviour.
 - Add timeouts per test case, e.g. `{ timeout: 10_000 }`, for long-running tests.
+
+### Running tests offline
+
+- Mirror CDN assets under `vendor/` with the same paths used in HTML and scripts.
+  - bootstrap@5.3.6 (CSS/JS), bootstrap-icons@1.13.1 (CSS/fonts), bootstrap-alert@1, saveform@1.2, marked@4.3.0, d3-dsv@3/+esm, pages for `news.ycombinator.com` and `www.hntoplinks.com/week`.
+- Extend `common/testutils.js` `virtualServers` with `https://cdn.jsdelivr.net/` and `https://llmfoundry.straive.com/` pointing to those mirrors.

--- a/githubstars/githubstars.test.js
+++ b/githubstars/githubstars.test.js
@@ -1,0 +1,43 @@
+import { describe, it, expect, beforeAll, afterAll, beforeEach, afterEach, vi } from "vitest";
+import { loadFrom } from "../common/testutils.js";
+
+describe("githubstars", () => {
+  let window, document, form, input, results;
+
+  const repo = {
+    full_name: "octocat/Hello-World",
+    name: "Hello-World",
+    stargazers_count: 80,
+    forks_count: 20,
+    pushed_at: "2024-01-01T00:00:00Z",
+  };
+
+  beforeAll(() => vi.useFakeTimers());
+  afterAll(() => vi.useRealTimers());
+
+  beforeEach(async () => {
+    const realFetch = fetch;
+    vi.stubGlobal("fetch", (url) => {
+      if (url.includes("api.github.com/repos/octocat/Hello-World"))
+        return Promise.resolve(new Response(JSON.stringify(repo)));
+      return realFetch(url);
+    });
+    ({ window, document } = await loadFrom(import.meta.dirname));
+    window.setTimeout = setTimeout;
+    form = document.getElementById("repoForm");
+    input = document.getElementById("inputText");
+    results = document.getElementById("resultsTable");
+  });
+  afterEach(() => {
+    vi.restoreAllMocks();
+    vi.unstubAllGlobals();
+  });
+
+  it("fetches repo stars and rewrites text", () => {
+    input.value = "[hw](https://github.com/octocat/Hello-World)";
+    form.dispatchEvent(new window.Event("submit", { bubbles: true, cancelable: true }));
+    const row = results.querySelector("tbody tr");
+    expect(row.textContent).toContain("octocat/Hello-World");
+    expect(input.value).toContain("80 ⭐ Jan 2024");
+  });
+});

--- a/githubsummary/githubsummary.test.js
+++ b/githubsummary/githubsummary.test.js
@@ -1,0 +1,78 @@
+import { describe, it, expect, beforeAll, afterAll, beforeEach, afterEach, vi } from "vitest";
+import { loadFrom } from "../common/testutils.js";
+
+const event = {
+  type: "PushEvent",
+  repo: { name: "octocat/Hello-World" },
+  payload: { ref: "refs/heads/main", commits: [{ message: "Test" }] },
+  created_at: "2024-06-01T00:00:00Z",
+};
+const repo = {
+  full_name: "octocat/Hello-World",
+  description: "Repo",
+  stargazers_count: 1,
+  forks_count: 0,
+  open_issues_count: 0,
+};
+
+const encoder = new TextEncoder();
+function openaiStream() {
+  return new ReadableStream({
+    start(controller) {
+      controller.enqueue(encoder.encode('data: {"choices":[{"delta":{"content":"Summary"}}]}\n\n'));
+      controller.enqueue(encoder.encode("data: [DONE]\n\n"));
+      controller.close();
+    },
+  });
+}
+
+describe("githubsummary", () => {
+  let window, document, form, generateBtn;
+
+  beforeAll(() => vi.useFakeTimers());
+  afterAll(() => vi.useRealTimers());
+
+  beforeEach(async () => {
+    const realFetch = fetch;
+    vi.stubGlobal("fetch", (url) => {
+      if (typeof url === "string") {
+        if (url.startsWith("https://cdn.jsdelivr.net/npm/bootstrap-llm-provider@1"))
+          return Promise.resolve(
+            new Response(
+              "export async function openaiConfig(){return {apiKey:'k', baseUrl:'https://api.openai.com/v1'};}",
+            ),
+          );
+        if (url.includes("api.github.com/users/testuser/events")) {
+          const page = new URL(url).searchParams.get("page");
+          const data = page === "1" ? [event] : [];
+          return Promise.resolve(new Response(JSON.stringify(data)));
+        }
+        if (url.includes("api.github.com/repos/octocat/Hello-World"))
+          return Promise.resolve(new Response(JSON.stringify(repo)));
+        if (url.includes("api.openai.com/v1/chat/completions"))
+          return Promise.resolve(new Response(openaiStream(), { headers: { "Content-Type": "text/event-stream" } }));
+      }
+      return realFetch(url);
+    });
+    ({ window, document } = await loadFrom(import.meta.dirname));
+    window.setTimeout = setTimeout;
+    form = document.getElementById("github-form");
+    generateBtn = document.getElementById("generate-summary-btn");
+  });
+  afterEach(() => {
+    vi.restoreAllMocks();
+    vi.unstubAllGlobals();
+  });
+
+  it("summarizes GitHub activity", async () => {
+    document.getElementById("username").value = "testuser";
+    document.getElementById("since").value = "2024-01-01";
+    document.getElementById("until").value = "2024-12-31";
+    document.querySelector("#system-prompt-tab-content textarea").value = "Summarize";
+    form.dispatchEvent(new window.Event("submit", { bubbles: true, cancelable: true }));
+    await Promise.resolve();
+    generateBtn.click();
+    await Promise.resolve();
+    expect(document.getElementById("results-content").textContent).toContain("Summary");
+  });
+});

--- a/githubusers/githubusers.test.js
+++ b/githubusers/githubusers.test.js
@@ -1,0 +1,55 @@
+import { describe, it, expect, beforeAll, afterAll, beforeEach, afterEach, vi } from "vitest";
+import { loadFrom } from "../common/testutils.js";
+
+describe("githubusers", () => {
+  let window, document, form, urls, results, copyBtn;
+
+  const user = {
+    html_url: "https://github.com/octocat",
+    avatar_url: "https://avatars.githubusercontent.com/u/1?v=4",
+    name: "The Octocat",
+    company: "GitHub",
+    blog: "https://github.blog",
+    location: "Earth",
+    email: null,
+    hireable: null,
+    bio: "Hi",
+    twitter_username: "octotwitter",
+    public_repos: 2,
+    public_gists: 1,
+    followers: 3,
+    following: 4,
+    created_at: "2020-01-01T00:00:00Z",
+    updated_at: "2020-01-02T00:00:00Z",
+  };
+
+  beforeAll(() => vi.useFakeTimers());
+  afterAll(() => vi.useRealTimers());
+
+  beforeEach(async () => {
+    const realFetch = fetch;
+    vi.stubGlobal("fetch", (url) => {
+      if (url.includes("api.github.com/users/octocat")) return Promise.resolve(new Response(JSON.stringify(user)));
+      return realFetch(url);
+    });
+    ({ window, document } = await loadFrom(import.meta.dirname));
+    window.setTimeout = setTimeout;
+    form = document.getElementById("urlForm");
+    urls = document.getElementById("urls");
+    results = document.getElementById("results");
+    copyBtn = document.getElementById("copyToExcelBtn");
+  });
+  afterEach(() => {
+    vi.restoreAllMocks();
+    vi.unstubAllGlobals();
+  });
+
+  it("fetches user data and copies", async () => {
+    urls.value = "https://github.com/octocat";
+    form.dispatchEvent(new window.Event("submit", { bubbles: true, cancelable: true }));
+    await Promise.resolve();
+    expect(results.querySelector("tbody tr")).not.toBeNull();
+    copyBtn.click();
+    expect(await window.navigator.clipboard.readText()).toContain("The Octocat");
+  });
+});

--- a/joincsv/joincsv.test.js
+++ b/joincsv/joincsv.test.js
@@ -1,0 +1,27 @@
+import { describe, it, expect, beforeAll, afterAll, beforeEach, afterEach, vi } from "vitest";
+import { loadFrom } from "../common/testutils.js";
+
+describe("joincsv", () => {
+  let window, document, tablesInput, joinBtn, output, copyBtn;
+
+  beforeAll(() => vi.useFakeTimers());
+  afterAll(() => vi.useRealTimers());
+
+  beforeEach(async () => {
+    ({ window, document } = await loadFrom(import.meta.dirname));
+    window.setTimeout = setTimeout;
+    tablesInput = document.getElementById("tables");
+    joinBtn = document.getElementById("joinBtn");
+    output = document.getElementById("output");
+    copyBtn = document.getElementById("copyBtn");
+  });
+  afterEach(() => vi.restoreAllMocks());
+
+  it("joins tables and copies", async () => {
+    tablesInput.value = "id,a\n1,x\n\n\nid,b\n1,y";
+    joinBtn.click();
+    expect(output.value.trim()).toBe("id,a,b\n1,x,y");
+    copyBtn.click();
+    expect(await window.navigator.clipboard.readText()).toBe("id\ta\tb\n1\tx\ty");
+  });
+});

--- a/md2csv/md2csv.test.js
+++ b/md2csv/md2csv.test.js
@@ -1,0 +1,34 @@
+import { describe, it, expect, beforeAll, afterAll, beforeEach, afterEach, vi } from "vitest";
+import { loadFrom } from "../common/testutils.js";
+
+describe("md2csv", () => {
+  let window, document, input, extractBtn, output, copyBtn;
+
+  beforeAll(() => vi.useFakeTimers());
+  afterAll(() => vi.useRealTimers());
+
+  beforeEach(async () => {
+    ({ window, document } = await loadFrom(import.meta.dirname));
+    window.setTimeout = setTimeout;
+    input = document.getElementById("markdownInput");
+    extractBtn = document.getElementById("extractBtn");
+    output = document.getElementById("output");
+    copyBtn = document.getElementById("copyBtn");
+  });
+  afterEach(() => vi.restoreAllMocks());
+
+  it("converts markdown table", async () => {
+    input.value = `|a|b|\n|-|-|\n|1|2|`;
+    extractBtn.click();
+    const cells = Array.from(output.querySelectorAll("td")).map((c) => c.textContent);
+    expect(cells).toEqual(["1", "2"]);
+    copyBtn.click();
+    expect(await window.navigator.clipboard.readText()).toBe("a\tb\n1\t2");
+  });
+
+  it("shows error on missing table", () => {
+    input.value = "no table";
+    extractBtn.click();
+    expect(document.querySelector(".alert")).not.toBeNull();
+  });
+});

--- a/recall/recall.test.js
+++ b/recall/recall.test.js
@@ -1,0 +1,31 @@
+import { describe, it, expect, beforeAll, afterAll, beforeEach, afterEach, vi } from "vitest";
+import { loadFrom } from "../common/testutils.js";
+
+const markdown = `- first\n- second\n- ⭐ star`;
+
+describe("recall", () => {
+  let window, document, content, starBtn;
+
+  beforeAll(() => vi.useFakeTimers());
+  afterAll(() => vi.useRealTimers());
+
+  beforeEach(async () => {
+    const realFetch = fetch;
+    vi.stubGlobal("fetch", (url) => Promise.resolve({ ok: true, text: () => Promise.resolve(markdown) }));
+    ({ window, document } = await loadFrom(import.meta.dirname));
+    window.setTimeout = setTimeout;
+    content = document.getElementById("content");
+    starBtn = document.getElementById("star-btn");
+    fetch = realFetch;
+  });
+  afterEach(() => {
+    vi.restoreAllMocks();
+    vi.unstubAllGlobals();
+  });
+
+  it("loads markdown and filters stars", () => {
+    expect(content.textContent.trim()).not.toBe("");
+    starBtn.click();
+    expect(content.textContent.trim()).toBe("⭐ star");
+  });
+});


### PR DESCRIPTION
## Problem
Missing automated coverage for several utility tools.

## Changes
- add recall tests with mocked markdown fetches
- add joincsv tests verifying merge and clipboard copy
- add md2csv tests for table parsing and errors
- add githubusers tests with stubbed GitHub API
- add githubstars tests parsing repo metadata
- add githubsummary tests with mocked GitHub and OpenAI responses

## Review
- **Safe**: tests only; no runtime code touched
- **Scrutinize**: API stubs in `githubsummary.test.js`

## Verification
1. `npm run lint`
2. `npm test` *(fails: network unreachable for CDN resources)*

## Deployment
- No runtime changes; low risk

## Learnings
- Use `vi.stubGlobal` to mock network APIs in Vitest
- Stream OpenAI responses via custom `ReadableStream` in tests

------
https://chatgpt.com/codex/tasks/task_e_68934d680854832c8eba91124d5e7662