### PR TITLE
test: add local asset mirroring

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -30,12 +30,9 @@ Common layout: each tool has `index.html` linking Bootstrap 5, bootstrap-icons@1
 ## Running tests
 
 1. Run `npm ci`
-2. Before running `npm test`, mirror CDN assets under `vendor/` with the same paths used in HTML and scripts. E.g. `curl -L https://cdn.jsdelivr.net/npm/bootstrap@5.3.6/dist/css/bootstrap.min.css -o vendor/npm/bootstrap@5.3.6/dist/css/bootstrap.min.css`
-   - Mirror bootstrap@5.3.6 (CSS/JS), bootstrap-icons@1.13.1 (CSS/fonts), bootstrap-alert@1, saveform@1.2, marked@4.3.0, d3-dsv@3/+esm
-   - Mirror pages for `news.ycombinator.com`, `www.hntoplinks.com/week`, etc.
-3. Extend `common/testutils.js` `virtualServers` with `https://cdn.jsdelivr.net/`, `https://news.ycombinator.com/`, etc. pointing to those mirrors.
-4. `npm test` tests all tools
-5. `npm test -- ${tool}/${tool}.test.js` tests a single tool
+2. `./test-local.sh` mirrors CDN assets under `vendor/`
+3. `VITE_TEST_LOCAL=1 npm test` tests all tools
+4. `VITE_TEST_LOCAL=1 npm test -- ${tool}/${tool}.test.js` tests a single tool
 
 ## Writing tests
 

--- a/common/testutils.js
+++ b/common/testutils.js
@@ -4,9 +4,17 @@ import { fileURLToPath } from "url";
 
 const root = path.dirname(path.dirname(fileURLToPath(import.meta.url)));
 
+const servers = [{ url: "https://test/", directory: root }];
+if (import.meta.env?.VITE_TEST_LOCAL)
+  servers.push(
+    { url: "https://cdn.jsdelivr.net/npm/", directory: path.join(root, "vendor/npm") },
+    { url: "https://news.ycombinator.com/", directory: path.join(root, "vendor/news.ycombinator.com") },
+    { url: "https://www.hntoplinks.com/", directory: path.join(root, "vendor/www.hntoplinks.com") },
+  );
+
 const browser = new Browser({
   console,
-  settings: { fetch: { virtualServers: [{ url: "https://test/", directory: root }] } },
+  settings: { fetch: { virtualServers: servers } },
 });
 
 export async function load(page, url) {

--- a/test-local.sh
+++ b/test-local.sh
@@ -1,0 +1,30 @@
+#!/usr/bin/env bash
+set -euo pipefail
+root=$(dirname "$0")
+vendor="$root/vendor"
+
+fetch() {
+  local url=$1 dest=$2 dir
+  dir=$(dirname "$dest")
+  mkdir -p "$dir"
+  curl -fsSL "$url" -o "$dest"
+}
+
+assets=(
+  "https://cdn.jsdelivr.net/npm/bootstrap@5.3.6/dist/css/bootstrap.min.css" "$vendor/npm/bootstrap@5.3.6/dist/css/bootstrap.min.css"
+  "https://cdn.jsdelivr.net/npm/bootstrap@5.3.6/dist/js/bootstrap.bundle.min.js" "$vendor/npm/bootstrap@5.3.6/dist/js/bootstrap.bundle.min.js"
+  "https://cdn.jsdelivr.net/npm/bootstrap-icons@1.13.1/font/bootstrap-icons.css" "$vendor/npm/bootstrap-icons@1.13.1/font/bootstrap-icons.css"
+  "https://cdn.jsdelivr.net/npm/bootstrap-icons@1.13.1/font/fonts/bootstrap-icons.woff2" "$vendor/npm/bootstrap-icons@1.13.1/font/fonts/bootstrap-icons.woff2"
+  "https://cdn.jsdelivr.net/npm/bootstrap-alert@1" "$vendor/npm/bootstrap-alert@1"
+  "https://cdn.jsdelivr.net/npm/saveform@1.2" "$vendor/npm/saveform@1.2"
+  "https://cdn.jsdelivr.net/npm/marked@4.3.0" "$vendor/npm/marked@4.3.0"
+  "https://cdn.jsdelivr.net/npm/d3-dsv@3/+esm" "$vendor/npm/d3-dsv@3/+esm"
+  "https://news.ycombinator.com/" "$vendor/news.ycombinator.com/index.html"
+  "https://www.hntoplinks.com/week" "$vendor/www.hntoplinks.com/week/index.html"
+)
+
+for ((i=0; i<${#assets[@]}; i+=2)); do
+  fetch "${assets[i]}" "${assets[i+1]}"
+done
+
+echo "Assets mirrored under $vendor"


### PR DESCRIPTION
## Problem
Offline tests required manual CDN mirroring and custom setup.

## Changes
- add `test-local.sh` to mirror CDN and news pages
- wire optional virtual servers in `common/testutils.js`
- document new flow in `AGENTS.md`

## Review
- ensure `test-local.sh` covers required assets
- confirm `VITE_TEST_LOCAL` gating in `common/testutils.js`
- docs: `AGENTS.md`

## Verification
1. `npm ci`
2. `./test-local.sh`
3. `VITE_TEST_LOCAL=1 npm test`

## Deployment
- No runtime impact

## Learning
- Mapping virtual servers enables offline testing when assets are mirrored


------
https://chatgpt.com/codex/tasks/task_e_689364af1fb4832c94cbb0d44f7f693b