### PR TITLE
feat: generate picbook panels from story

### DIFF
--- a/common/testutils.js
+++ b/common/testutils.js
@@ -16,7 +16,7 @@ if (fs.existsSync(path.join(root, "vendor")))
     {
       url: "https://llmfoundry.straive.com/-/proxy/https://www.hntoplinks.com/",
       directory: path.join(root, "vendor/www.hntoplinks.com"),
-    }
+    },
   );
 
 const browser = new Browser({

--- a/picbook/index.html
+++ b/picbook/index.html
@@ -103,7 +103,7 @@
             <button id="create-btn" type="button" class="btn btn-outline-primary"><i class="bi bi-magic me-1"></i>Create panels</button>
           </div>
           <label for="panels" class="form-label mt-3">Panels</label>
-          <textarea id="panels" rows="7" class="form-control" placeholder="Panel caption to display [Image generation prompt for LLM]"></textarea>
+          <textarea id="panels" rows="10" class="form-control" placeholder="Panel caption to display [Image generation prompt for LLM]"></textarea>
           <div class="d-flex justify-content-end gap-2 mt-2">
             <button id="start-btn" class="btn btn-primary" type="submit"><i class="bi bi-play-fill me-1"></i>Draw</button>
             <button id="openai-config-btn" type="button" class="btn btn-outline-secondary"><i class="bi bi-gear me-1"></i>Configure OpenAI</button>

--- a/picbook/index.html
+++ b/picbook/index.html
@@ -97,10 +97,15 @@
           </div>
         </div>
         <div class="col-lg-8">
-          <label for="panels" class="form-label">Panels</label>
-          <textarea id="panels" rows="16" class="form-control" placeholder="One line per panel, each in the format 'Text caption to display [Prompt for LLM]'"></textarea>
+          <label for="story" class="form-label">Story</label>
+          <textarea id="story" rows="7" class="form-control" placeholder="Paste story here"></textarea>
+          <div class="d-flex justify-content-end mt-2">
+            <button id="create-btn" type="button" class="btn btn-outline-primary"><i class="bi bi-magic me-1"></i>Create panels</button>
+          </div>
+          <label for="panels" class="form-label mt-3">Panels</label>
+          <textarea id="panels" rows="7" class="form-control" placeholder="Panel caption to display [Image generation prompt for LLM]"></textarea>
           <div class="d-flex justify-content-end gap-2 mt-2">
-            <button id="start-btn" class="btn btn-primary" type="submit"><i class="bi bi-play-fill me-1"></i>Start</button>
+            <button id="start-btn" class="btn btn-primary" type="submit"><i class="bi bi-play-fill me-1"></i>Draw</button>
             <button id="openai-config-btn" type="button" class="btn btn-outline-secondary"><i class="bi bi-gear me-1"></i>Configure OpenAI</button>
             <button type="reset" class="btn btn-outline-secondary"><i class="bi bi-arrow-counterclockwise me-1"></i>Reset</button>
           </div>

--- a/recall/script.js
+++ b/recall/script.js
@@ -55,7 +55,7 @@ let starOnly = false;
 let fuse;
 
 files.forEach((f) =>
-  fileSelect.insertAdjacentHTML("beforeend", /* html */ `<option value="${f.url}">${f.name}</option>`)
+  fileSelect.insertAdjacentHTML("beforeend", /* html */ `<option value="${f.url}">${f.name}</option>`),
 );
 
 async function load(url) {


### PR DESCRIPTION
## Summary
- add story field and Create panels generator that streams LLM output into panel list
- trim panels area and rename Start button to Draw

## Testing
- `npm run lint`
- `npm test`
- `npm run screenshot -- picbook/ picbook/screenshot.webp`


------
https://chatgpt.com/codex/tasks/task_e_6897225b89fc832cbecca4a3b4651487