### PR TITLE
feat: edit ideator notes and expose prompt

### DIFF
--- a/ideator/README.md
+++ b/ideator/README.md
@@ -8,3 +8,5 @@ Ideator fuses notes into a single idea via ChatGPT.
 - Reload or delete individual notes
 - Add more notes and set a goal (default: Innovative web app)
 - Opens ChatGPT (gpt-5-thinking) with a fused prompt
+- Edit notes before ideating
+- View and copy the prompt template

--- a/ideator/ideator.test.js
+++ b/ideator/ideator.test.js
@@ -6,7 +6,6 @@ const { document } = window;
 global.window = window;
 global.document = document;
 
-vi.mock("https://cdn.jsdelivr.net/npm/marked/+esm", () => ({ marked: { parse: (s) => s } }));
 vi.mock("https://cdn.jsdelivr.net/npm/bootstrap-alert@1", () => ({ bootstrapAlert: vi.fn() }));
 vi.mock("../recall/notes.js", () => ({
   files: [
@@ -20,7 +19,7 @@ vi.mock("../recall/notes.js", () => ({
 beforeEach(() => {
   vi.resetModules();
   document.body.innerHTML =
-    '<input id="goal-input"><button id="add-btn"></button><button id="ideate-btn"></button><div id="notes"></div>';
+    '<input id="goal-input"><button id="add-btn"></button><button id="ideate-btn"></button><div id="notes"></div><pre id="prompt-template"></pre>';
   window.open = vi.fn();
 });
 
@@ -36,5 +35,16 @@ describe("ideator", () => {
     await import("./script.js");
     document.querySelectorAll(".note-delete")[1].click();
     expect(document.querySelectorAll(".note-card").length).toBe(1);
+  });
+
+  it("uses edited notes", async () => {
+    await import("./script.js");
+    const card = document.querySelector(".note-card");
+    const text = card.querySelector(".note-text");
+    text.value = "Edited";
+    text.dispatchEvent(new window.Event("input"));
+    document.getElementById("ideate-btn").click();
+    const url = new URL(window.open.mock.calls[0][0]);
+    expect(url.searchParams.get("q")).toContain("Edited");
   });
 });

--- a/ideator/index.html
+++ b/ideator/index.html
@@ -67,6 +67,10 @@
               <button id="ideate-btn" class="btn btn-success btn-sm" title="Ideate"><i class="bi bi-lightbulb"></i> <span class="d-none d-sm-inline">Ideate</span></button>
               <button id="add-btn" class="btn btn-secondary btn-sm" title="Add concept"><i class="bi bi-plus"></i> <span class="d-none d-sm-inline">Add concept</span></button>
             </div>
+            <details class="mt-3">
+              <summary>Prompt template</summary>
+              <pre id="prompt-template" class="form-control mt-2"></pre>
+            </details>
           </div>
         </div>
       </div>


### PR DESCRIPTION
## Summary
- allow editing fetched notes before ideation
- show system prompt template with `__GOAL__` and `__NOTES__` tokens
- test edited notes are included in ChatGPT prompt

## Testing
- `npx -y prettier@3.5 --print-width=120 -w '**/*.js' '**/*.md'`
- `npx -y js-beautify@1 '**/*.html' --type html --replace --indent-size 2 --max-preserve-newlines 1 --end-with-newline`
- `npm run lint`
- `npm test -- ideator`
- `npm run screenshot -- ideator/ ideator/screenshot.webp` *(fails: Executable doesn't exist at chromium_headless_shell)*


------
https://chatgpt.com/codex/tasks/task_e_689aef81dffc832ca03f48ea960c990c