### PR TITLE
feat(recall): add quiz button

### DIFF
--- a/recall/index.html
+++ b/recall/index.html
@@ -22,6 +22,7 @@
       <button id="next-btn" class="btn btn-outline-primary btn-sm"><i class="bi bi-arrow-right"></i></button>
       <button id="star-btn" class="btn btn-outline-warning btn-sm"><i class="bi bi-star"></i></button>
       <button id="copy-btn" class="btn btn-secondary btn-sm"><i class="bi bi-clipboard"></i> Copy</button>
+      <button id="quiz-btn" class="btn btn-success btn-sm"><i class="bi bi-question-circle"></i> <span class="d-none d-sm-inline">Quiz</span></button>
     </div>
   </div>
   <div class="container py-4" style="max-width: 40rem">

--- a/recall/script.js
+++ b/recall/script.js
@@ -7,6 +7,7 @@ const content = document.getElementById("content");
 const fileSelect = document.getElementById("file-select");
 const randomBtn = document.getElementById("random-btn");
 const copyBtn = document.getElementById("copy-btn");
+const quizBtn = document.getElementById("quiz-btn");
 const starBtn = document.getElementById("star-btn");
 const decayInput = document.getElementById("decay-input");
 const indexInput = document.getElementById("index-input");
@@ -101,6 +102,13 @@ searchInput.oninput = applyFilter;
 copyBtn.onclick = async () => {
   await navigator.clipboard.writeText(view[index] || "");
   bootstrapAlert({ body: "Copied", color: "success", replace: true });
+};
+
+quizBtn.onclick = () => {
+  const note = view[index];
+  if (!note) return bootstrapAlert({ body: "No note", color: "danger", replace: true });
+  const q = `${note}\n\nQuiz me so I can learn this better. Search online for more information if required.`;
+  window.open(`https://chatgpt.com/?model=gpt-5-thinking&q=${encodeURIComponent(q)}`, "_blank");
 };
 
 starBtn.onclick = () => {


### PR DESCRIPTION
## Summary
- add Quiz button in Recall tool to send current note to ChatGPT with study prompt
- show icon-only on small screens for responsive layout

## Testing
- `npm run lint`
- `npm test -- recall` *(fails: No test files found)*

------
https://chatgpt.com/codex/tasks/task_e_689c65c40780832cbc911a826d5a5823