### PR TITLE
Add LLM diff-based document editor

### DIFF
--- a/llmedit/README.md
+++ b/llmedit/README.md
@@ -1,0 +1,5 @@
+# LLM Document Editor
+
+Edit a document with natural language prompts. The prompt and document are sent to an LLM, which replies with a diff in [diff-match-patch](https://github.com/google/diff-match-patch) format. The diff is applied to the document in place.
+
+Configure API keys with bootstrap-llm-provider. Form state persists with saveform. Errors and missing patches are shown using bootstrap-alert.

--- a/llmedit/index.html
+++ b/llmedit/index.html
@@ -1,0 +1,54 @@
+<!doctype html>
+<html lang="en">
+
+<head>
+  <meta charset="UTF-8" />
+  <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+  <title>LLM Document Editor</title>
+  <link rel="icon" type="image/svg+xml" href="data:image/svg+xml;base64,PHN2ZyB4bWxucz0iaHR0cDovL3d3dy53My5vcmcvMjAwMC9zdmciIHZpZXdCb3g9IjAgMCAzMiAzMiI+PGNpcmNsZSBjeD0iMTYiIGN5PSIxNiIgcj0iMTUiIGZpbGw9IiMyNTYzZWIiLz48cGF0aCBmaWxsPSIjZmZmIiBkPSJtMTYgNyAyIDcgNyAyLTcgMi0yIDctMi03LTctMiA3LTJaIi8+PC9zdmc+" />
+  <link href="https://cdn.jsdelivr.net/npm/bootstrap@5.3.6/dist/css/bootstrap.min.css" rel="stylesheet" />
+  <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/bootstrap-icons@1.13.1/font/bootstrap-icons.css" />
+</head>
+
+<body>
+  <nav class="navbar navbar-expand-lg bg-body-tertiary mb-4">
+    <div class="container">
+      <a class="navbar-brand d-flex align-items-center" href="../">
+        <i class="bi bi-pencil-square me-2"></i>
+        LLM Document Editor
+      </a>
+      <div class="bootstrap-dark-theme"></div>
+    </div>
+  </nav>
+  <div class="container">
+    <p class="text-secondary">Describe desired edits on the left; the model returns diffs applied to the document on the right.</p>
+    <div class="row g-4">
+      <div class="col-md-4">
+        <form id="llmedit-form" class="d-flex flex-column h-100">
+          <label for="prompt-input" class="form-label">Prompt</label>
+          <textarea id="prompt-input" class="form-control mb-3 flex-grow-1" rows="8"></textarea>
+          <div class="d-flex gap-2">
+            <button type="submit" class="btn btn-primary flex-grow-1">Apply</button>
+            <button type="button" id="openai-config-btn" class="btn btn-outline-secondary">Config</button>
+          </div>
+        </form>
+        <div id="loading" class="text-center my-3 d-none">
+          <div class="spinner-border" role="status"></div>
+        </div>
+      </div>
+      <div class="col-md-8">
+        <label for="doc-area" class="form-label">Document</label>
+        <textarea id="doc-area" class="form-control" rows="20">Lorem ipsum dolor sit amet, consectetur adipiscing elit. Sed non risus. Suspendisse lectus tortor, dignissim sit amet, adipiscing nec, ultricies sed, dolor.
+
+Cras elementum ultrices diam. Maecenas ligula massa, varius a, semper congue, euismod non, mi. Proin porttitor, orci nec nonummy molestie, enim est eleifend mi, non fermentum diam nisl sit amet erat.
+
+Duis semper. Duis arcu massa, scelerisque vitae, consequat in, pretium a, enim. Pellentesque congue.</textarea>
+      </div>
+    </div>
+  </div>
+  <script src="https://cdn.jsdelivr.net/npm/bootstrap@5.3.6/dist/js/bootstrap.bundle.min.js"></script>
+  <script src="https://cdn.jsdelivr.net/npm/bootstrap-dark-theme@1" type="module"></script>
+  <script type="module" src="script.js"></script>
+</body>
+
+</html>

--- a/llmedit/llmedit.test.js
+++ b/llmedit/llmedit.test.js
@@ -1,0 +1,48 @@
+import { describe, it, expect, beforeEach, vi } from "vitest";
+import { Window } from "happy-dom";
+
+const window = new Window();
+const { document } = window;
+global.window = window;
+global.document = document;
+
+vi.mock("https://cdn.jsdelivr.net/npm/saveform@1.2", () => ({ default: vi.fn() }));
+vi.mock("https://cdn.jsdelivr.net/npm/bootstrap-alert@1", () => ({ bootstrapAlert: vi.fn() }));
+vi.mock("https://cdn.jsdelivr.net/npm/bootstrap-llm-provider@1", () => ({
+  openaiConfig: vi.fn().mockResolvedValue({ apiKey: "k", baseUrl: "https://api" }),
+}));
+vi.mock("https://cdn.jsdelivr.net/npm/asyncllm@2", () => ({
+  asyncLLM: vi.fn(() =>
+    (async function* () {
+      yield { content: '{"text":"Edited"}' };
+    })(),
+  ),
+}));
+vi.mock("https://cdn.jsdelivr.net/npm/diff-match-patch@1/+esm", () => ({
+  default: class {
+    patch_fromText(t) {
+      return JSON.parse(t).text;
+    }
+    patch_apply(p, text) {
+      return [p, [true]];
+    }
+  },
+}));
+
+beforeEach(() => {
+  vi.resetModules();
+  document.body.innerHTML =
+    '<form id="llmedit-form"><textarea id="prompt-input"></textarea><button></button></form><textarea id="doc-area"></textarea><div id="loading" class="d-none"></div><button id="openai-config-btn"></button>';
+});
+
+describe("llmedit", () => {
+  it("applies diff to document", async () => {
+    await import("./script.js");
+    const doc = document.getElementById("doc-area");
+    doc.value = "Original";
+    document.getElementById("prompt-input").value = "Edit";
+    document.getElementById("llmedit-form").dispatchEvent(new window.Event("submit"));
+    await new Promise((r) => setTimeout(r, 0));
+    expect(doc.value).toBe("Edited");
+  });
+});

--- a/llmedit/script.js
+++ b/llmedit/script.js
@@ -1,0 +1,54 @@
+import saveform from "https://cdn.jsdelivr.net/npm/saveform@1.2";
+import { openaiConfig } from "https://cdn.jsdelivr.net/npm/bootstrap-llm-provider@1";
+import { bootstrapAlert } from "https://cdn.jsdelivr.net/npm/bootstrap-alert@1";
+import DiffMatchPatch from "https://cdn.jsdelivr.net/npm/diff-match-patch@1/+esm";
+import { asyncLLM } from "https://cdn.jsdelivr.net/npm/asyncllm@2";
+
+const qs = (id) => document.getElementById(id);
+const ui = {
+  form: qs("llmedit-form"),
+  prompt: qs("prompt-input"),
+  doc: qs("doc-area"),
+  loading: qs("loading"),
+  configBtn: qs("openai-config-btn"),
+};
+
+saveform("#llmedit-form");
+const dmp = new DiffMatchPatch();
+
+ui.configBtn.addEventListener("click", () => openaiConfig({ show: true }));
+
+ui.form.addEventListener("submit", async (e) => {
+  e.preventDefault();
+  const p = ui.prompt.value.trim();
+  if (!p) return bootstrapAlert({ title: "Prompt missing", body: "Enter instructions", color: "warning" });
+  const { apiKey, baseUrl } = await openaiConfig({});
+  if (!apiKey) return bootstrapAlert({ title: "API key", body: "Configure OpenAI", color: "warning" });
+  const doc = ui.doc.value;
+  ui.loading.classList.remove("d-none");
+  let diffText = "";
+  const messages = [
+    { role: "system", content: "Edit the document per instruction and return diff-match-patch text" },
+    { role: "user", content: `Document:\n${doc}\n\nInstruction:\n${p}` },
+  ];
+  for await (const { content, error } of asyncLLM(`${baseUrl}/chat/completions`, {
+    method: "POST",
+    headers: { "Content-Type": "application/json", Authorization: `Bearer ${apiKey}` },
+    body: JSON.stringify({ model: "gpt-4.1-mini", messages }),
+  })) {
+    if (error) {
+      ui.loading.classList.add("d-none");
+      return bootstrapAlert({ title: "API error", body: error, color: "danger" });
+    }
+    diffText = content || "";
+  }
+  ui.loading.classList.add("d-none");
+  try {
+    const patches = dmp.patch_fromText(diffText);
+    const [res, ok] = dmp.patch_apply(patches, doc);
+    if (ok.some((v) => !v)) throw new Error("Patch mismatch");
+    ui.doc.value = res;
+  } catch (err) {
+    bootstrapAlert({ title: "Patch error", body: err.message, color: "danger" });
+  }
+});

--- a/tools.json
+++ b/tools.json
@@ -252,6 +252,13 @@
       "created": "2025-08-06T03:54:17+00:00"
     },
     {
+      "icon": "bi-pencil-square",
+      "title": "LLM Document Editor",
+      "description": "Apply LLM-generated diffs to a document.",
+      "url": "llmedit",
+      "created": "2025-08-14T03:45:15+00:00"
+    },
+    {
       "icon": "bi-markdown-fill",
       "title": "Render Markdown",
       "description": "Render Markdown to HTML using the GitHub Markdown API.",


### PR DESCRIPTION
## Summary
- build llmedit tool to edit documents via LLM-generated diff-match-patch patches
- wire up diff application, config storage, and error display with Bootstrap UI
- document tool and register in tools.json

## Testing
- `npm run lint`
- `npm test -- llmedit`
- `npm run screenshot -- llmedit/ llmedit/screenshot.webp` *(fails: browserType.launch: Executable doesn't exist at /root/.cache/ms-playwright/chromium_headless_shell-1181/chrome-linux/headless_shell)*

------
https://chatgpt.com/codex/tasks/task_e_689d5ab05dc4832c9e8f4c90d0bb6344