### PR TITLE
fix: preserve star toggle on reload

### DIFF
--- a/ideator/ideator.test.js
+++ b/ideator/ideator.test.js
@@ -49,4 +49,15 @@ describe("ideator", () => {
     const url = new URL(window.open.mock.calls[0][0]);
     expect(url.searchParams.get("q")).toContain("Edited");
   });
+
+  it("keeps star after reload", async () => {
+    await import("./script.js");
+    const card = document.querySelector(".note-card");
+    card.querySelector(".note-star").click();
+    await card.querySelector(".note-reload").onclick();
+    const btn = card.querySelector(".note-star");
+    expect(card.star).toBe(true);
+    expect(btn.className).toContain("btn-warning");
+    expect(btn.innerHTML).toContain("bi-star-fill");
+  });
 });

--- a/ideator/script.js
+++ b/ideator/script.js
@@ -91,9 +91,10 @@ async function reload(card) {
   const url = select.value;
   const urls = url ? [url] : files.map((f) => f.url);
   card.items = await fetchAll(urls);
-  card.star = false;
-  card.querySelector(".note-star").className = "btn btn-outline-warning btn-sm note-star";
-  card.querySelector(".note-star").innerHTML = /* html */ `<i class="bi bi-star"></i>`;
+  if (card.star === undefined) card.star = false;
+  const starBtn = card.querySelector(".note-star");
+  starBtn.className = `btn btn-${card.star ? "warning" : "outline-warning"} btn-sm note-star`;
+  starBtn.innerHTML = /* html */ `<i class="bi bi-${card.star ? "star-fill" : "star"}"></i>`;
   search.value = "";
   title.textContent = url ? files.find((f) => f.url === url)?.name : "All";
   update(card);


### PR DESCRIPTION
## Summary
- keep starred note state when reloading a card in ideator
- add regression test ensuring reload doesn't clear star toggle

## Testing
- `npm run lint`
- `npm test -- ideator`


------
https://chatgpt.com/codex/tasks/task_e_689de0b33980832c8bac6bf874ea3b9a