### PR TITLE
feat: add viva practice tool

### DIFF
--- a/viva/README.md
+++ b/viva/README.md
@@ -1,0 +1,3 @@
+# Viva
+
+Practice viva exams: record answers, transcribe, and get instant rubric feedback.

--- a/viva/config.json
+++ b/viva/config.json
@@ -1,0 +1,23 @@
+{
+  "exams": [
+    {
+      "id": "sample-student",
+      "title": "Sample Student Exam",
+      "windowStart": "2000-01-01T00:00:00Z",
+      "windowEnd": "2099-12-31T23:59:59Z",
+      "durationMin": 5,
+      "eligibleEmails": [],
+      "evaluationMode": "student",
+      "llmModel": "gpt-4o-mini",
+      "evalBatchSize": 1,
+      "rubricVersion": "v1",
+      "questions": [
+        {
+          "id": "q1",
+          "prompt": "Explain gravity.",
+          "rubricJson": "{\"categories\":[{\"id\":\"clarity\",\"weight\":1,\"instructions\":\"Be clear\"}]}"
+        }
+      ]
+    }
+  ]
+}

--- a/viva/index.html
+++ b/viva/index.html
@@ -1,0 +1,58 @@
+<!doctype html>
+<html lang="en">
+
+<head>
+  <meta charset="UTF-8" />
+  <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+  <title>Viva</title>
+  <link rel="icon" type="image/svg+xml" href="data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 16 16'%3E%3Cpath fill='%230d6efd' d='M8 0a8 8 0 1 0 0 16A8 8 0 0 0 8 0m3 11-3-2-3 2V5l3 2 3-2z'/%3E%3C/svg%3E" />
+  <link href="https://cdn.jsdelivr.net/npm/bootstrap@5.3.6/dist/css/bootstrap.min.css" rel="stylesheet" crossorigin="anonymous" />
+  <link href="https://cdn.jsdelivr.net/npm/bootstrap-icons@1.13.1/font/bootstrap-icons.css" rel="stylesheet" />
+</head>
+
+<body class="bg-light">
+  <nav class="navbar navbar-expand-lg bg-body-tertiary" data-bs-theme="dark">
+    <div class="container-fluid">
+      <a class="navbar-brand" href=".">Viva</a>
+      <div class="nav-item dropdown ms-auto">
+        <button class="dark-theme-toggle btn btn-outline-light dropdown-toggle" data-bs-toggle="dropdown" aria-label="Toggle theme">
+          <i class="bi bi-circle-half"></i>
+        </button>
+        <ul class="dropdown-menu dropdown-menu-end">
+          <li><button class="dropdown-item" data-bs-theme-value="light"><i class="bi bi-sun-fill me-2"></i>Light</button></li>
+          <li><button class="dropdown-item" data-bs-theme-value="dark"><i class="bi bi-moon-stars-fill me-2"></i>Dark</button></li>
+          <li><button class="dropdown-item" data-bs-theme-value="auto"><i class="bi bi-circle-half me-2"></i>Auto</button></li>
+        </ul>
+      </div>
+    </div>
+  </nav>
+  <div class="container py-4" id="app">
+    <div id="exam-list"></div>
+    <div id="mic-card" class="d-none mb-4">
+      <div class="card">
+        <div class="card-body">
+          <h2 class="h5">Mic check</h2>
+          <p class="mb-2">Record 10 seconds to ensure audio works.</p>
+          <button id="mic-start" class="btn btn-primary me-2">Start test</button>
+          <audio id="mic-audio" controls class="d-none w-100 my-2"></audio>
+          <button id="mic-continue" class="btn btn-success" disabled>Continue</button>
+        </div>
+      </div>
+    </div>
+    <div id="exam-runner" class="d-none">
+      <div id="question-prompt" class="mb-3"></div>
+      <button id="record-btn" class="btn btn-primary mb-2">Record</button>
+      <audio id="player" controls class="w-100 mb-2"></audio>
+      <button id="toggle-transcript" class="btn btn-secondary btn-sm mb-2">Show transcript</button>
+      <div id="transcript" class="border rounded p-2 mb-2 d-none"></div>
+      <div id="question-status" class="mb-2"></div>
+      <button id="next-btn" class="btn btn-outline-primary me-2">Next</button>
+      <button id="submit-btn" class="btn btn-success">Submit</button>
+      <div id="results" class="mt-3"></div>
+    </div>
+  </div>
+  <script src="https://cdn.jsdelivr.net/npm/bootstrap@5.3.6/dist/js/bootstrap.bundle.min.js" type="module" defer></script>
+  <script type="module" src="script.js"></script>
+</body>
+
+</html>

--- a/viva/script.js
+++ b/viva/script.js
@@ -1,0 +1,212 @@
+import { bootstrapAlert } from "https://cdn.jsdelivr.net/npm/bootstrap-alert@1";
+
+const DEFAULT_BASE_URLS = ["https://openrouter.ai/api/v1", "https://aipipe.org/openrouter/v1"];
+const state = { exams: [], current: null, index: 0, recordings: [], micDone: false };
+window.vivaState = state;
+
+const $list = document.getElementById("exam-list");
+const $mic = document.getElementById("mic-card");
+const $runner = document.getElementById("exam-runner");
+const $prompt = document.getElementById("question-prompt");
+const $record = document.getElementById("record-btn");
+const $player = document.getElementById("player");
+const $transcript = document.getElementById("transcript");
+const $toggle = document.getElementById("toggle-transcript");
+const $status = document.getElementById("question-status");
+const $next = document.getElementById("next-btn");
+const $submit = document.getElementById("submit-btn");
+const $results = document.getElementById("results");
+const $micStart = document.getElementById("mic-start");
+const $micAudio = document.getElementById("mic-audio");
+const $micContinue = document.getElementById("mic-continue");
+
+init();
+
+async function init() {
+  try {
+    const res = await fetch("config.json");
+    state.exams = (await res.json()).exams || [];
+    renderList();
+  } catch (e) {
+    showError("Config error", e);
+  }
+}
+
+function renderList() {
+  if (!state.exams.length) return $list.insertAdjacentHTML("afterbegin", "<p>No exams</p>");
+  const items = state.exams
+    .map((e) => `<li><button class="btn btn-link p-0 exam-btn" data-id="${e.id}">${e.title}</button></li>`)
+    .join("");
+  $list.innerHTML = `<ul class="list-unstyled">${items}</ul>`;
+  $list.querySelectorAll(".exam-btn").forEach((b) => b.addEventListener("click", () => start(b.dataset.id)));
+}
+
+function start(id) {
+  state.current = state.exams.find((e) => e.id === id);
+  if (!state.current) return;
+  state.index = 0;
+  state.recordings = state.current.questions.map(() => ({ audio: null, transcript: "", count: 0 }));
+  $list.classList.add("d-none");
+  $mic.classList.remove("d-none");
+}
+
+let rec;
+$micStart.addEventListener("click", async () => {
+  try {
+    const stream = await navigator.mediaDevices.getUserMedia({ audio: true });
+    const chunks = [];
+    rec = new MediaRecorder(stream);
+    rec.ondataavailable = (e) => chunks.push(e.data);
+    rec.onstop = () => {
+      const blob = new Blob(chunks, { type: "audio/webm" });
+      $micAudio.src = URL.createObjectURL(blob);
+      $micAudio.classList.remove("d-none");
+      $micContinue.disabled = false;
+    };
+    rec.start();
+    setTimeout(() => rec.stop(), 10000);
+  } catch (e) {
+    showError("Mic error", e);
+  }
+});
+$micContinue.addEventListener("click", () => {
+  state.micDone = true;
+  $mic.classList.add("d-none");
+  $runner.classList.remove("d-none");
+  renderQuestion();
+});
+
+function renderQuestion() {
+  const q = state.current.questions[state.index];
+  $prompt.textContent = q.prompt;
+  const r = state.recordings[state.index];
+  $player.src = r.audio || "";
+  $status.textContent = r.transcript ? "Saved" : "Not recorded";
+  $transcript.textContent = r.transcript;
+  $transcript.classList.add("d-none");
+  $toggle.textContent = "Show transcript";
+}
+
+$toggle.addEventListener("click", () => {
+  $transcript.classList.toggle("d-none");
+  $toggle.textContent = $transcript.classList.contains("d-none") ? "Show transcript" : "Hide transcript";
+});
+
+let media;
+$record.addEventListener("click", async () => {
+  if (media && media.state === "recording") return media.stop();
+  try {
+    const stream = await navigator.mediaDevices.getUserMedia({ audio: true });
+    const chunks = [];
+    media = new MediaRecorder(stream);
+    media.ondataavailable = (e) => chunks.push(e.data);
+    media.onstop = async () => {
+      const blob = new Blob(chunks, { type: "audio/webm" });
+      const url = URL.createObjectURL(blob);
+      const r = state.recordings[state.index];
+      if (r.audio) URL.revokeObjectURL(r.audio);
+      r.audio = url;
+      r.count++;
+      if (r.count > 2) bootstrapAlert({ title: "Hint", body: "Consider moving on and return later", color: "info" });
+      await transcribe(blob);
+      renderQuestion();
+    };
+    media.start();
+    $status.textContent = "Recording";
+    $record.textContent = "Stop";
+  } catch (e) {
+    showError("Mic error", e);
+  }
+});
+
+async function transcribe(blob) {
+  try {
+    $status.textContent = "Transcribing";
+    const { openaiConfig } = window.openaiConfig
+      ? { openaiConfig: window.openaiConfig }
+      : await import("https://cdn.jsdelivr.net/npm/bootstrap-llm-provider@1");
+    const { apiKey, baseUrl } = await openaiConfig({ defaultBaseUrls: DEFAULT_BASE_URLS });
+    const fd = new FormData();
+    fd.append("file", blob, "audio.webm");
+    fd.append("model", state.current.llmModel);
+    const res = await fetch(`${baseUrl}/audio/transcriptions`, {
+      method: "POST",
+      headers: { Authorization: `Bearer ${apiKey}` },
+      body: fd,
+    });
+    const data = await res.json();
+    state.recordings[state.index].transcript = data.text || "";
+    $status.textContent = "Saved";
+  } catch (e) {
+    showError("Transcription failed", e);
+  }
+}
+
+$next.addEventListener("click", () => {
+  if (state.index < state.current.questions.length - 1) {
+    state.index++;
+    renderQuestion();
+  }
+});
+
+$submit.addEventListener("click", submitExam);
+
+async function submitExam() {
+  const aud = state.recordings.map((r) => r.audio);
+  try {
+    if (state.current.evaluationMode !== "student") return showResults(null);
+    $results.innerHTML = spinner();
+    const evals = await evaluate();
+    showResults(evals);
+  } finally {
+    aud.forEach((u) => u && URL.revokeObjectURL(u));
+    state.recordings.forEach((r) => (r.audio = null));
+  }
+}
+
+function spinner() {
+  return '<div class="spinner-border" role="status"></div>';
+}
+
+async function evaluate() {
+  const { openaiConfig } = window.openaiConfig
+    ? { openaiConfig: window.openaiConfig }
+    : await import("https://cdn.jsdelivr.net/npm/bootstrap-llm-provider@1");
+  const { asyncLLM } = window.asyncLLM
+    ? { asyncLLM: window.asyncLLM }
+    : await import("https://cdn.jsdelivr.net/npm/asyncllm@2");
+  const { apiKey, baseUrl } = await openaiConfig({ defaultBaseUrls: DEFAULT_BASE_URLS });
+  const out = [];
+  for (const [i, q] of state.current.questions.entries()) {
+    let full;
+    const ans = state.recordings[i].transcript;
+    for await (const { content } of asyncLLM(`${baseUrl}/chat/completions`, {
+      method: "POST",
+      headers: { "Content-Type": "application/json", Authorization: `Bearer ${apiKey}` },
+      body: JSON.stringify({
+        model: state.current.llmModel,
+        messages: [
+          { role: "system", content: `Score using rubric ${q.rubricJson}` },
+          { role: "user", content: ans },
+        ],
+      }),
+    }))
+      full = content;
+    out.push(JSON.parse(full || "{}"));
+  }
+  return out;
+}
+
+function showResults(evals) {
+  const label = '<div class="alert alert-info">Practice—Not a Grade</div>';
+  if (!evals) return ($results.innerHTML = label + "<p>Results will be published later.</p>");
+  const details = evals
+    .map((r, i) => `<div><strong>Q${i + 1}</strong>: ${(r.totalScore ?? 0).toFixed(2)}</div>`)
+    .join("");
+  $results.innerHTML = label + details;
+  [$record, $player, $toggle, $next, $submit].forEach((el) => el.classList.add("d-none"));
+}
+
+function showError(title, e) {
+  bootstrapAlert({ title, body: e.message, color: "danger" });
+}

--- a/viva/viva.test.js
+++ b/viva/viva.test.js
@@ -1,0 +1,34 @@
+import { describe, it, expect, beforeAll, afterAll, vi } from "vitest";
+import { loadFrom } from "../common/testutils.js";
+
+describe("Viva", () => {
+  let window, document;
+  beforeAll(async () => {
+    vi.useFakeTimers();
+    ({ window, document } = await loadFrom(import.meta.dirname));
+  });
+
+  afterAll(() => vi.useRealTimers());
+
+  it("evaluates and hides audio", async () => {
+    document.querySelector(".exam-btn").click();
+    const cont = document.getElementById("mic-continue");
+    cont.disabled = false;
+    cont.click();
+    window.vivaState.recordings[0].transcript = "answer";
+    const transcript = document.getElementById("transcript");
+    expect(transcript.classList.contains("d-none")).toBe(true);
+    document.getElementById("toggle-transcript").click();
+    expect(transcript.classList.contains("d-none")).toBe(false);
+    window.openaiConfig = vi.fn(async () => ({ apiKey: "k", baseUrl: "https://test" }));
+    window.asyncLLM = async function* () {
+      yield { content: JSON.stringify({ totalScore: 0.7 }) };
+    };
+    document.getElementById("submit-btn").click();
+    await vi.runAllTimersAsync();
+    const text = document.getElementById("results").textContent;
+    expect(text).toMatch(/Practice/);
+    expect(text).toMatch(/0.7/);
+    expect(window.vivaState.recordings[0].audio).toBe(null);
+  });
+});


### PR DESCRIPTION
## Summary
- add viva practice exam app with mic check, recording, transcription and LLM scoring
- hide rubric when faculty mode and drop audio after submit
- cover transcript toggle, evaluation and cleanup in tests

## Testing
- `npm run lint`
- `npm test -- viva`


------
https://chatgpt.com/codex/tasks/task_e_68a2a5d81c84832cac251e2100d52bd7