### PR TITLE
feat: add threadchat discussion app

### DIFF
--- a/common/testutils.js
+++ b/common/testutils.js
@@ -2,6 +2,7 @@ import { Browser } from "happy-dom";
 import path from "path";
 import fs from "node:fs";
 import { fileURLToPath } from "url";
+import "fake-indexeddb/auto";
 
 const root = path.dirname(path.dirname(fileURLToPath(import.meta.url)));
 
@@ -39,6 +40,17 @@ export async function load(page, url) {
 
 export async function loadFrom(dirPath, file = "index.html") {
   const page = browser.newPage();
+  Object.assign(page.mainFrame.window, {
+    indexedDB,
+    IDBKeyRange,
+    IDBDatabase,
+    IDBObjectStore,
+    IDBTransaction,
+    IDBRequest,
+    IDBCursor,
+    IDBOpenDBRequest,
+    IDBIndex,
+  });
   return await load(page, `https://test/${path.basename(dirPath)}/${file}`);
 }
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -5,6 +5,7 @@
   "packages": {
     "": {
       "devDependencies": {
+        "fake-indexeddb": "^5.0.2",
         "happy-dom": "^17.6.3",
         "playwright": "^1.54.1",
         "sharp": "^0.34.3",
@@ -1508,6 +1509,16 @@
       "license": "Apache-2.0",
       "engines": {
         "node": ">=12.0.0"
+      }
+    },
+    "node_modules/fake-indexeddb": {
+      "version": "5.0.2",
+      "resolved": "https://registry.npmjs.org/fake-indexeddb/-/fake-indexeddb-5.0.2.tgz",
+      "integrity": "sha512-cB507r5T3D55DfclY01GLkninZLfU7HXV/mhVRTnTRm5k2u+fY7Fof2dBkr80p5t7G7dlA/G5dI87QiMdPpMCQ==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "engines": {
+        "node": ">=18"
       }
     },
     "node_modules/fdir": {

--- a/package.json
+++ b/package.json
@@ -10,6 +10,7 @@
     "test:watch": "vitest"
   },
   "devDependencies": {
+    "fake-indexeddb": "^5.0.2",
     "happy-dom": "^17.6.3",
     "playwright": "^1.54.1",
     "sharp": "^0.34.3",

--- a/test-setup.sh
+++ b/test-setup.sh
@@ -26,6 +26,7 @@ assets=(
   "https://cdn.jsdelivr.net/npm/saveform@1.2" "$vendor/npm/saveform@1.2"
   "https://cdn.jsdelivr.net/npm/marked@4.3.0" "$vendor/npm/marked@4.3.0"
   "https://cdn.jsdelivr.net/npm/d3-dsv@3/+esm" "$vendor/npm/d3-dsv@3/+esm"
+  "https://cdn.jsdelivr.net/npm/fake-indexeddb@5/+esm" "$vendor/npm/fake-indexeddb@5/+esm"
   "https://news.ycombinator.com/" "$vendor/news.ycombinator.com/index.html"
   "https://www.hntoplinks.com/week" "$vendor/www.hntoplinks.com/week"
 )

--- a/threadchat/index.html
+++ b/threadchat/index.html
@@ -1,0 +1,74 @@
+<!DOCTYPE html>
+<html lang="en">
+
+<head>
+  <meta charset="utf-8" />
+  <meta name="viewport" content="width=device-width, initial-scale=1" />
+  <title>ThreadChat</title>
+  <link rel="icon" href="data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 16 16'%3E%3Ctext y='14'%3E💬%3C/text%3E%3C/svg%3E" />
+  <link href="https://cdn.jsdelivr.net/npm/bootstrap@5.3.6/dist/css/bootstrap.min.css" rel="stylesheet" />
+  <link href="https://cdn.jsdelivr.net/npm/bootstrap-icons@1.13.1/font/bootstrap-icons.css" rel="stylesheet" />
+</head>
+
+<body>
+  <div id="app" class="bootstrap-dark-theme">
+    <nav class="navbar navbar-expand-sm bg-body-tertiary mb-3">
+      <div class="container-fluid">
+        <a class="navbar-brand" href="#top">ThreadChat</a>
+        <button class="navbar-toggler" type="button" data-bs-toggle="collapse" data-bs-target="#nav-content">
+          <span class="navbar-toggler-icon"></span>
+        </button>
+        <div class="collapse navbar-collapse" id="nav-content">
+          <ul class="navbar-nav me-auto mb-2 mb-sm-0">
+            <li class="nav-item"><a class="nav-link" href="#top">Top</a></li>
+            <li class="nav-item"><a class="nav-link" href="#new">New</a></li>
+            <li class="nav-item"><a class="nav-link" href="#ask">Ask</a></li>
+            <li class="nav-item"><a class="nav-link" href="#show">Show</a></li>
+            <li class="nav-item"><a class="nav-link" href="#submit">Submit</a></li>
+          </ul>
+          <div id="auth-area" class="d-flex gap-2"></div>
+        </div>
+      </div>
+    </nav>
+    <main class="container" id="view"></main>
+  </div>
+
+  <div class="modal fade" id="signup-modal" tabindex="-1">
+    <div class="modal-dialog">
+      <div class="modal-content">
+        <div class="modal-header">
+          <h5 class="modal-title">Sign up</h5>
+        </div>
+        <div class="modal-body">
+          <form id="signup-form" class="d-flex flex-column gap-2">
+            <input class="form-control" id="signup-user" placeholder="Username" required />
+            <input class="form-control" id="signup-pass" type="password" placeholder="Password" required />
+            <button class="btn btn-primary" id="signup-btn" type="submit">Create account</button>
+          </form>
+        </div>
+      </div>
+    </div>
+  </div>
+
+  <div class="modal fade" id="signin-modal" tabindex="-1">
+    <div class="modal-dialog">
+      <div class="modal-content">
+        <div class="modal-header">
+          <h5 class="modal-title">Sign in</h5>
+        </div>
+        <div class="modal-body">
+          <form id="signin-form" class="d-flex flex-column gap-2">
+            <input class="form-control" id="signin-user" placeholder="Username" required />
+            <input class="form-control" id="signin-pass" type="password" placeholder="Password" required />
+            <button class="btn btn-primary" id="signin-btn" type="submit">Sign in</button>
+          </form>
+        </div>
+      </div>
+    </div>
+  </div>
+
+  <script type="module" src="script.js"></script>
+  <script src="https://cdn.jsdelivr.net/npm/bootstrap@5.3.6/dist/js/bootstrap.bundle.min.js"></script>
+</body>
+
+</html>

--- a/threadchat/script.js
+++ b/threadchat/script.js
@@ -1,0 +1,352 @@
+import { bootstrapAlert } from "https://cdn.jsdelivr.net/npm/bootstrap-alert@1";
+import saveform from "https://cdn.jsdelivr.net/npm/saveform@1.2";
+if (!window.indexedDB) {
+  if (!globalThis.structuredClone) globalThis.structuredClone = (o) => JSON.parse(JSON.stringify(o));
+  const f = await import("https://cdn.jsdelivr.net/npm/fake-indexeddb@5/+esm");
+  Object.assign(window, f);
+}
+
+const DB_NAME = "threadchat";
+let db;
+
+async function openDB() {
+  if (db) return db;
+  return new Promise((resolve, reject) => {
+    const req = indexedDB.open(DB_NAME, 1);
+    req.onupgradeneeded = () => {
+      const d = req.result;
+      d.createObjectStore("users", { keyPath: "name" });
+      d.createObjectStore("posts", { keyPath: "id", autoIncrement: true }).createIndex("time", "time");
+      const c = d.createObjectStore("comments", { keyPath: "id", autoIncrement: true });
+      c.createIndex("post", "post");
+      c.createIndex("parent", "parent");
+      const v = d.createObjectStore("votes", { keyPath: ["kind", "item", "by"] });
+      v.createIndex("item", ["kind", "item"]);
+      d.createObjectStore("meta", { keyPath: "key" });
+    };
+    req.onsuccess = () => ((db = req.result), resolve(db));
+    req.onerror = () => reject(req.error);
+  });
+}
+
+async function tx(names, mode = "readonly") {
+  const d = await openDB();
+  return d.transaction(names, mode);
+}
+
+function store(t, name) {
+  return t.objectStore(name);
+}
+function getAll(s, q) {
+  return new Promise((r) => {
+    const req = q !== undefined ? s.getAll(q) : s.getAll();
+    req.onsuccess = () => r(req.result);
+  });
+}
+
+async function hash(str) {
+  const buf = await crypto.subtle.digest("SHA-256", new TextEncoder().encode(str));
+  return [...new Uint8Array(buf)].map((b) => b.toString(16).padStart(2, "0")).join("");
+}
+
+function user() {
+  return localStorage.getItem("threadchat-user");
+}
+function setUser(name) {
+  name ? localStorage.setItem("threadchat-user", name) : localStorage.removeItem("threadchat-user");
+}
+
+async function seed() {
+  const t = await tx(["meta"], "readwrite");
+  const m = store(t, "meta");
+  const done = await new Promise((r) => {
+    const g = m.get("seeded");
+    g.onsuccess = () => r(g.result);
+  });
+  if (done) return;
+  const tt = await tx(["users", "posts", "comments", "votes", "meta"], "readwrite");
+  const u = store(tt, "users");
+  const p = store(tt, "posts");
+  const c = store(tt, "comments");
+  await new Promise((r) => {
+    const req = u.put({ name: "alice", pass: "" });
+    req.onsuccess = r;
+  });
+  const now = Date.now();
+  const postId = await new Promise((r) => {
+    const req = p.add({ title: "Welcome", url: "", text: "Hello", by: "alice", time: now });
+    req.onsuccess = (e) => r(e.target.result);
+  });
+  await new Promise((r) => {
+    const req = c.add({ post: postId, parent: null, text: "First comment", by: "alice", time: now });
+    req.onsuccess = r;
+  });
+  await new Promise((r) => {
+    const req = store(tt, "meta").put({ key: "seeded" });
+    req.onsuccess = r;
+  });
+}
+
+async function resetDB() {
+  indexedDB.deleteDatabase(DB_NAME);
+  db = undefined;
+  await openDB();
+  await seed();
+  route();
+}
+
+function spinner() {
+  return '<div class="d-flex justify-content-center my-3"><div class="spinner-border"></div></div>';
+}
+
+async function signup(e) {
+  e.preventDefault();
+  const name = document.getElementById("signup-user").value.trim();
+  const pass = document.getElementById("signup-pass").value;
+  if (!name || !pass) return;
+  const exists = await new Promise(async (r) => {
+    const req = store(await tx(["users"]), "users").get(name);
+    req.onsuccess = () => r(req.result);
+  });
+  if (exists) return bootstrapAlert({ title: "Error", body: "User exists", color: "danger" });
+  const hashed = await hash(pass);
+  await new Promise(async (r) => {
+    const req = store(await tx(["users"], "readwrite"), "users").put({ name, pass: hashed, created: Date.now() });
+    req.onsuccess = r;
+  });
+  setUser(name);
+  bootstrapAlert({ title: "Welcome", body: name });
+  document.getElementById("signup-form").reset();
+  const m = bootstrap.Modal.getInstance(document.getElementById("signup-modal"));
+  if (m) m.hide();
+  renderAuth();
+  route();
+}
+
+async function signin(e) {
+  e.preventDefault();
+  const name = document.getElementById("signin-user").value.trim();
+  const pass = document.getElementById("signin-pass").value;
+  const t = await tx(["users"]);
+  const s = store(t, "users");
+  const userObj = await new Promise((r) => {
+    const req = s.get(name);
+    req.onsuccess = () => r(req.result);
+  });
+  if (!userObj) return bootstrapAlert({ title: "Error", body: "No such user", color: "danger" });
+  const hashed = await hash(pass);
+  if (userObj.pass !== hashed) return bootstrapAlert({ title: "Error", body: "Bad password", color: "danger" });
+  setUser(name);
+  bootstrapAlert({ title: "Hi", body: name });
+  document.getElementById("signin-form").reset();
+  const m = bootstrap.Modal.getInstance(document.getElementById("signin-modal"));
+  if (m) m.hide();
+  renderAuth();
+  route();
+}
+
+function signout() {
+  setUser();
+  renderAuth();
+  route();
+}
+
+function renderAuth() {
+  const area = document.getElementById("auth-area");
+  area.replaceChildren();
+  const u = user();
+  if (!u) {
+    area.insertAdjacentHTML(
+      "beforeend",
+      '<button class="btn btn-outline-light" data-bs-toggle="modal" data-bs-target="#signup-modal">Sign up</button>',
+    );
+    area.insertAdjacentHTML(
+      "beforeend",
+      '<button class="btn btn-outline-light" data-bs-toggle="modal" data-bs-target="#signin-modal">Sign in</button>',
+    );
+  } else {
+    area.insertAdjacentHTML("beforeend", `<span class="navbar-text">${u}</span>`);
+    area.insertAdjacentHTML("beforeend", '<button class="btn btn-outline-light" id="signout-btn">Sign out</button>');
+    document.getElementById("signout-btn").onclick = signout;
+  }
+}
+
+async function addPost(e) {
+  e.preventDefault();
+  const title = document.getElementById("submit-title").value.trim();
+  const url = document.getElementById("submit-url").value.trim();
+  const text = document.getElementById("submit-text").value.trim();
+  if (!title) return;
+  const by = user();
+  if (!by) return bootstrapAlert({ title: "Error", body: "Sign in first", color: "danger" });
+  const t = await tx(["posts"], "readwrite");
+  await new Promise((r) => {
+    const req = store(t, "posts").add({ title, url, text, by, time: Date.now() });
+    req.onsuccess = r;
+  });
+  location.hash = "#new";
+}
+
+async function vote(kind, item) {
+  const by = user();
+  if (!by) return bootstrapAlert({ title: "Error", body: "Sign in", color: "danger" });
+  const t = await tx(["votes"], "readwrite");
+  const s = store(t, "votes");
+  const key = [kind, item, by];
+  const has = await new Promise((r) => {
+    const req = s.get(key);
+    req.onsuccess = () => r(req.result);
+  });
+  if (has) return;
+  await new Promise((r) => {
+    const req = s.put({ kind, item, by });
+    req.onsuccess = r;
+  });
+  route();
+}
+
+async function addComment(post, parent, text) {
+  const by = user();
+  if (!by) return bootstrapAlert({ title: "Error", body: "Sign in", color: "danger" });
+  const t = await tx(["comments"], "readwrite");
+  await new Promise((r) => {
+    const req = store(t, "comments").add({ post, parent, text, by, time: Date.now() });
+    req.onsuccess = r;
+  });
+  route();
+}
+
+function fmtTime(t) {
+  return new Date(t).toLocaleString();
+}
+
+async function postStats(id) {
+  const t = await tx(["comments", "votes"]);
+  const comments = await getAll(store(t, "comments").index("post"), id);
+  const votes = await getAll(store(t, "votes").index("item"), ["post", id]);
+  const last = Math.max(0, ...comments.map((c) => c.time));
+  return { score: votes.length, comments: comments.length, updated: Math.max(last, (await getPost(id)).time) };
+}
+
+async function getPost(id) {
+  const t = await tx(["posts"]);
+  return await new Promise((r) => {
+    const req = store(t, "posts").get(id);
+    req.onsuccess = () => r(req.result);
+  });
+}
+
+async function list(filter) {
+  const t = await tx(["posts"]);
+  const posts = await getAll(store(t, "posts"));
+  const enriched = [];
+  for (const p of posts) {
+    if (filter === "ask" && p.url) continue;
+    if (filter === "show" && !p.url) continue;
+    const s = await postStats(p.id);
+    enriched.push({ ...p, ...s });
+  }
+  enriched.sort(filter === "new" ? (a, b) => b.time - a.time : (a, b) => b.score - a.score);
+  return enriched;
+}
+
+function postHTML(p) {
+  const domain = p.url ? new URL(p.url).hostname.replace(/^www\./, "") : "";
+  return `<div class="mb-2"><div class="d-flex gap-2"><button class="btn btn-sm btn-outline-secondary" data-vote="${p.id}"><i class="bi bi-caret-up"></i></button><a href="#thread-${p.id}">${p.title}</a>${p.url ? `<small class="text-muted">(${domain})</small>` : ""}</div><small class="text-muted">${p.score} points by <a href="#user-${p.by}">${p.by}</a> | ${p.comments} comments | updated ${fmtTime(p.updated)}</small></div>`;
+}
+
+async function renderList(filter) {
+  const view = document.getElementById("view");
+  view.innerHTML = spinner();
+  const posts = await list(filter);
+  const html = posts.map(postHTML).join("") || "<p>No posts</p>";
+  view.innerHTML = `<div>${html}${posts.length ? "" : ""}</div>`;
+  view.querySelectorAll("[data-vote]").forEach((btn) => (btn.onclick = () => vote("post", parseInt(btn.dataset.vote))));
+}
+
+function commentHTML(c, depth) {
+  const pad = depth * 20;
+  return `<div style="margin-left:${pad}px" class="mb-2"><div class="d-flex gap-2"><button class="btn btn-sm btn-outline-secondary" data-vote="c-${c.id}"><i class="bi bi-caret-up"></i></button><b>${c.by}</b> <small class="text-muted">${fmtTime(c.time)}</small></div><div>${c.text}</div><button class="btn btn-link btn-sm p-0" data-reply="${c.id}">reply</button><div data-children="${c.id}"></div></div>`;
+}
+
+async function renderThread(id) {
+  const post = await getPost(id);
+  if (!post) return;
+  const stats = await postStats(id);
+  const view = document.getElementById("view");
+  view.innerHTML = spinner();
+  const head = `<h3>${post.title}</h3><p><a href="${post.url}">${post.url}</a></p><p>${post.text || ""}</p><small class="text-muted">${stats.score} points by <a href="#user-${post.by}">${post.by}</a></small><div class="my-3"><textarea id="new-comment" class="form-control" rows="3"></textarea><button class="btn btn-primary mt-2" id="comment-btn">add comment</button></div><div id="comments"></div>`;
+  view.innerHTML = head;
+  document.getElementById("comment-btn").onclick = () => {
+    const txt = document.getElementById("new-comment").value.trim();
+    if (txt) addComment(post.id, null, txt);
+  };
+  await renderComments(post.id);
+}
+
+async function renderComments(postId) {
+  const t = await tx(["comments"]);
+  const all = await getAll(store(t, "comments").index("post"), postId);
+  const root = all.filter((c) => c.parent === null);
+  const byParent = {};
+  for (const c of all) (byParent[c.parent] || (byParent[c.parent] = [])).push(c);
+  const cont = document.getElementById("comments");
+  cont.replaceChildren();
+  const render = (items, depth) => {
+    for (const c of items) {
+      cont.insertAdjacentHTML("beforeend", commentHTML(c, depth));
+      cont.querySelector(`[data-vote="c-${c.id}"]`).onclick = () => vote("comment", c.id);
+      const replyBtn = cont.querySelector(`[data-reply="${c.id}"]`);
+      replyBtn.onclick = () => {
+        const txt = prompt("reply");
+        if (txt) addComment(postId, c.id, txt);
+      };
+      const children = byParent[c.id] || [];
+      if (children.length) render(children, depth + 1);
+    }
+  };
+  render(root, 0);
+}
+
+async function renderSubmit() {
+  const view = document.getElementById("view");
+  view.innerHTML = `<form id="submit-form" class="d-flex flex-column gap-2"><input id="submit-title" class="form-control" placeholder="Title" required /><input id="submit-url" class="form-control" placeholder="URL" /><textarea id="submit-text" class="form-control" rows="3" placeholder="Text"></textarea><button class="btn btn-primary" type="submit">Post</button></form>`;
+  const f = document.getElementById("submit-form");
+  saveform(f);
+  f.onsubmit = addPost;
+}
+
+async function renderUser(name) {
+  const t = await tx(["users", "posts", "comments", "votes"]);
+  const u = await new Promise((r) => {
+    const req = store(t, "users").get(name);
+    req.onsuccess = () => r(req.result);
+  });
+  if (!u) return;
+  const posts = (await getAll(store(t, "posts").index("time"))).filter((p) => p.by === name);
+  const comments = (await getAll(store(t, "comments"))).filter((c) => c.by === name);
+  let karma = 0;
+  for (const p of posts) karma += (await getAll(store(t, "votes").index("item"), ["post", p.id])).length;
+  for (const c of comments) karma += (await getAll(store(t, "votes").index("item"), ["comment", c.id])).length;
+  const view = document.getElementById("view");
+  const htmlPosts = posts.map((p) => `<li><a href="#thread-${p.id}">${p.title}</a></li>`).join("");
+  const htmlComments = comments.map((c) => `<li>${c.text}</li>`).join("");
+  view.innerHTML = `<h3>${name}</h3><p>Joined ${fmtTime(u.created)}</p><p>Karma ${karma}</p><h5>Posts</h5><ul>${htmlPosts}</ul><h5>Comments</h5><ul>${htmlComments}</ul><button id="reset-btn" class="btn btn-danger btn-sm">Reset DB</button>`;
+  document.getElementById("reset-btn").onclick = resetDB;
+}
+
+async function route() {
+  await seed();
+  const hash = location.hash || "#top";
+  if (hash.startsWith("#thread-")) return renderThread(parseInt(hash.split("-")[1]));
+  if (hash.startsWith("#user-")) return renderUser(hash.split("-")[1]);
+  if (hash === "#submit") return renderSubmit();
+  if (["#top", "#new", "#ask", "#show"].includes(hash)) return renderList(hash.slice(1));
+  renderList("top");
+}
+
+renderAuth();
+window.addEventListener("hashchange", route);
+document.getElementById("signup-form").onsubmit = signup;
+document.getElementById("signin-form").onsubmit = signin;
+setTimeout(route);

--- a/threadchat/threadchat.test.js
+++ b/threadchat/threadchat.test.js
@@ -1,0 +1,93 @@
+import { describe, it, beforeAll, afterAll, expect, vi } from "vitest";
+import "fake-indexeddb/auto";
+import { loadFrom } from "../common/testutils.js";
+
+describe("threadchat", () => {
+  beforeAll(() => vi.useFakeTimers());
+  afterAll(() => vi.useRealTimers());
+
+  async function mount() {
+    const { page, window, document } = await loadFrom("threadchat");
+    window.setTimeout = setTimeout;
+    Object.assign(window, {
+      indexedDB,
+      IDBKeyRange,
+      IDBDatabase,
+      IDBObjectStore,
+      IDBTransaction,
+      IDBRequest,
+      IDBCursor,
+      IDBOpenDBRequest,
+      IDBIndex,
+    });
+    await vi.runAllTimersAsync();
+    return { page, window, document };
+  }
+
+  async function navigate(window, hash) {
+    window.location.hash = hash;
+    window.dispatchEvent(new window.HashChangeEvent("hashchange"));
+    await vi.runAllTimersAsync();
+    await Promise.resolve();
+  }
+
+  it(
+    "full flow",
+    async () => {
+      const { window, document } = await mount();
+
+      // sign up
+      document.getElementById("signup-user").value = "bob";
+      document.getElementById("signup-pass").value = "pw";
+      document
+        .getElementById("signup-form")
+        .dispatchEvent(new window.Event("submit", { bubbles: true, cancelable: true }));
+
+      // submit post
+      await navigate(window, "#submit");
+      document.getElementById("submit-title").value = "My Post";
+      document.getElementById("submit-text").value = "Hello world";
+      document
+        .getElementById("submit-form")
+        .dispatchEvent(new window.Event("submit", { bubbles: true, cancelable: true }));
+      await navigate(window, "#new");
+      expect(document.body.textContent).toContain("My Post");
+
+      // vote dedupe
+      const voteBtn = document.querySelector("[data-vote]");
+      voteBtn.click();
+      await navigate(window, window.location.hash);
+      voteBtn.click();
+      await navigate(window, window.location.hash);
+      expect(document.body.textContent).toContain("1 points");
+
+      // comment and reply
+      document.querySelector('a[href^="#thread-"]').click();
+      await navigate(window, window.location.hash);
+      for (let i = 0; i < 5 && !document.getElementById("new-comment"); i++)
+        await navigate(window, window.location.hash);
+      document.getElementById("new-comment").value = "first";
+      document.getElementById("comment-btn").click();
+      await navigate(window, window.location.hash);
+      const promptSpy = vi.spyOn(window, "prompt").mockReturnValue("second");
+      document.querySelector("[data-reply]").click();
+      promptSpy.mockRestore();
+      await navigate(window, window.location.hash);
+
+      // back to list
+      await navigate(window, "#new");
+      expect(document.body.textContent).toMatch(/2 comments/);
+
+      // profile karma
+      document.querySelector("span.navbar-text").click();
+      await navigate(window, "#user-bob");
+      expect(document.body.textContent).toContain("Karma 1");
+
+      // reset
+      document.getElementById("reset-btn").click();
+      await navigate(window, window.location.hash);
+      expect(document.body.textContent).toContain("Welcome");
+    },
+    { timeout: 10000 },
+  );
+});


### PR DESCRIPTION
## Summary
- add ThreadChat client-only discussion tool with Bootstrap UI and IndexedDB storage
- support sign-up/in modals, post listing, voting, commenting, and profile views
- add tests and fake-indexeddb setup for browser simulation

## Testing
- `uvx ruff check --line-length 100 .`
- `npx -y js-beautify@1 '**/*.html' --type html --replace --indent-size 2 --max-preserve-newlines 1 --end-with-newline`
- `npx -y prettier@3.5 --print-width=120 --write '**/*.js' '**/*.md'`
- `npm test -- threadchat` *(fails: Cannot set properties of null)*

------
https://chatgpt.com/codex/tasks/task_e_68a6d4f8dee0832ca941e5781eee6bf4