### PR TITLE
Add voice notes tool with Gemini transcription

### DIFF
--- a/tools.json
+++ b/tools.json
@@ -189,6 +189,13 @@
       "created": "2025-06-04T11:25:48+08:00"
     },
     {
+      "icon": "bi-mic-fill",
+      "title": "Voice Notes",
+      "description": "Record voice notes and transcribe with Gemini 2.5 Flash.",
+      "url": "voicenotes",
+      "created": "2025-08-16T00:00:00+00:00"
+    },
+    {
       "icon": "bi-file-slides-fill",
       "title": "RevealJS Slides",
       "description": "Convert Markdown to RevealJS HTML.",

--- a/voicenotes/README.md
+++ b/voicenotes/README.md
@@ -1,0 +1,8 @@
+# Voice Notes
+
+Record voice notes and transcribe them with Gemini 2.5 Flash.
+
+- Click **Record** to capture audio. Click again to stop.
+- Each transcription appears at the top of the list.
+- Delete unwanted notes or copy all notes as a Markdown list.
+- Notes persist in your browser.

--- a/voicenotes/index.html
+++ b/voicenotes/index.html
@@ -1,0 +1,31 @@
+<!doctype html>
+<html lang="en">
+
+<head>
+  <meta charset="UTF-8" />
+  <meta name="viewport" content="width=device-width, initial-scale=1" />
+  <title>Voice Notes</title>
+  <link rel="icon" type="image/svg+xml" href="data:image/svg+xml;base64,PHN2ZyB4bWxucz0iaHR0cDovL3d3dy53My5vcmcvMjAwMC9zdmciIHZpZXdCb3g9IjAgMCAzMiAzMiI+PGNpcmNsZSBjeD0iMTYiIGN5PSIxNiIgcj0iMTUiIGZpbGw9IiMyNTYzZWIiLz48cGF0aCBmaWxsPSIjZmZmIiBkPSJtMTYgNyAyIDcgNyAyLTcgMi0yIDctMi03LTctMiA3LTJaIi8+PC9zdmc+" />
+  <link href="https://cdn.jsdelivr.net/npm/bootstrap@5.3.6/dist/css/bootstrap.min.css" rel="stylesheet" crossorigin="anonymous" />
+  <link href="https://cdn.jsdelivr.net/npm/bootstrap-icons@1.13.1/font/bootstrap-icons.css" rel="stylesheet" crossorigin="anonymous" />
+</head>
+
+<body class="bg-light">
+  <nav class="navbar navbar-expand-lg bg-body-tertiary" data-bs-theme="dark">
+    <div class="container-fluid">
+      <a class="navbar-brand" href="..">Voice Notes</a>
+    </div>
+  </nav>
+  <div class="container py-4">
+    <div class="mb-3 d-flex align-items-center">
+      <button id="record-btn" class="btn btn-primary me-2"><i class="bi bi-mic-fill me-1"></i>Record</button>
+      <button id="openai-config-btn" class="btn btn-outline-secondary me-2">Config</button>
+      <div id="spinner" class="spinner-border text-primary d-none" style="width:1.5rem;height:1.5rem" role="status"><span class="visually-hidden">Loading...</span></div>
+      <button id="copy-btn" class="btn btn-outline-secondary ms-2"><i class="bi bi-clipboard"></i> Copy Markdown</button>
+    </div>
+    <ul id="notes-list" class="list-group"></ul>
+  </div>
+  <script type="module" src="script.js"></script>
+</body>
+
+</html>

--- a/voicenotes/script.js
+++ b/voicenotes/script.js
@@ -1,0 +1,104 @@
+import { html, render } from "https://cdn.jsdelivr.net/npm/lit-html/+esm";
+import { bootstrapAlert } from "https://cdn.jsdelivr.net/npm/bootstrap-alert@1";
+import { openaiConfig } from "https://cdn.jsdelivr.net/npm/bootstrap-llm-provider@1";
+import { asyncLLM } from "https://cdn.jsdelivr.net/npm/asyncllm@2";
+
+const recordBtn = document.getElementById("record-btn");
+const configBtn = document.getElementById("openai-config-btn");
+const spinner = document.getElementById("spinner");
+const copyBtn = document.getElementById("copy-btn");
+const list = document.getElementById("notes-list");
+
+const STORAGE_KEY = "voice-notes";
+let chunks = [];
+let recorder;
+
+const loadNotes = () => JSON.parse(localStorage.getItem(STORAGE_KEY) || "[]");
+let notes = loadNotes();
+const saveNotes = () => localStorage.setItem(STORAGE_KEY, JSON.stringify(notes));
+
+export function addNote(text) {
+  notes.unshift({ text, ts: Date.now() });
+  saveNotes();
+  renderNotes();
+}
+
+function renderNotes() {
+  const items = notes.sort((a, b) => b.ts - a.ts);
+  render(
+    items.map(
+      (n, i) =>
+        html`<li class="list-group-item d-flex justify-content-between align-items-start">
+          <span>${n.text}</span
+          ><button class="btn btn-sm btn-outline-danger" data-index="${i}"><i class="bi bi-trash"></i></button>
+        </li>`,
+    ),
+    list,
+  );
+}
+
+renderNotes();
+
+configBtn.addEventListener("click", () => openaiConfig({ show: true }));
+
+recordBtn.addEventListener("click", async () => {
+  if (!recorder) {
+    try {
+      const stream = await navigator.mediaDevices.getUserMedia({ audio: true });
+      recorder = new MediaRecorder(stream);
+      recorder.addEventListener("dataavailable", (e) => chunks.push(e.data));
+      recorder.addEventListener("stop", transcribe);
+      recorder.start();
+      recordBtn.classList.add("btn-danger");
+      recordBtn.textContent = "Stop";
+    } catch {
+      bootstrapAlert({ title: "Mic error", body: "Microphone access denied", color: "danger" });
+    }
+  } else {
+    recorder.stop();
+    recorder = null;
+    recordBtn.classList.remove("btn-danger");
+    recordBtn.textContent = "Record";
+  }
+});
+
+async function transcribe() {
+  const blob = new Blob(chunks, { type: "audio/webm" });
+  chunks = [];
+  const buffer = await blob.arrayBuffer();
+  const base64 = btoa(String.fromCharCode(...new Uint8Array(buffer)));
+  const { apiKey, baseUrl } = await openaiConfig({});
+  if (!apiKey) return;
+  spinner.classList.remove("d-none");
+  for await (const { content, error } of asyncLLM(`${baseUrl}/v1beta/models/gemini-2.5-flash:transcribe`, {
+    method: "POST",
+    headers: { "Content-Type": "application/json", Authorization: `Bearer ${apiKey}` },
+    body: JSON.stringify({ audio: { content: base64, mimeType: blob.type } }),
+  })) {
+    spinner.classList.add("d-none");
+    if (error) {
+      bootstrapAlert({ title: "Transcription error", body: error, color: "danger" });
+      return;
+    }
+    const text = content?.text ?? content ?? "";
+    addNote(text);
+  }
+}
+
+list.addEventListener("click", (e) => {
+  const btn = e.target.closest("button");
+  if (!btn) return;
+  const i = +btn.dataset.index;
+  notes.splice(i, 1);
+  saveNotes();
+  renderNotes();
+});
+
+export function copyNotes() {
+  const md = notes.map((n) => `- ${n.text}`).join("\n");
+  return navigator.clipboard.writeText(md);
+}
+
+copyBtn.addEventListener("click", () => {
+  copyNotes();
+});

--- a/voicenotes/script.test.js
+++ b/voicenotes/script.test.js
@@ -1,0 +1,64 @@
+import { describe, it, beforeEach, expect, vi, afterAll, beforeAll } from "vitest";
+import { Window } from "happy-dom";
+import fs from "node:fs/promises";
+import path from "node:path";
+import { fileURLToPath, pathToFileURL } from "node:url";
+
+vi.mock("https://cdn.jsdelivr.net/npm/lit-html/+esm", () => ({
+  html: (s, ...v) => s.reduce((acc, cur, i) => acc + cur + (v[i] ?? ""), ""),
+  render: (c, el) => {
+    el.innerHTML = Array.isArray(c) ? c.join("") : c;
+  },
+}));
+vi.mock("https://cdn.jsdelivr.net/npm/bootstrap-alert@1", () => ({ bootstrapAlert: vi.fn() }));
+vi.mock("https://cdn.jsdelivr.net/npm/bootstrap-llm-provider@1", () => ({
+  openaiConfig: vi.fn(async () => ({ apiKey: "k", baseUrl: "https://g" })),
+}));
+vi.mock("https://cdn.jsdelivr.net/npm/asyncllm@2", () => ({ asyncLLM: vi.fn() }));
+
+let html;
+const __dirname = path.dirname(fileURLToPath(import.meta.url));
+const scriptURL = pathToFileURL(path.join(__dirname, "script.js")).href;
+const htmlPath = path.join(__dirname, "index.html");
+
+beforeAll(async () => {
+  vi.useFakeTimers();
+  html = await fs.readFile(htmlPath, "utf8");
+});
+
+afterAll(() => vi.useRealTimers());
+
+describe("voicenotes", () => {
+  let window, document, addNote, copyNotes;
+  beforeEach(async () => {
+    window = new Window({ url: "https://test/voicenotes/" });
+    document = window.document;
+    const body = html
+      .match(/<body[^>]*>([\s\S]*)<\/body>/i)[1]
+      .replace(/<script[^>]*src="script.js"[^>]*><\/script>/, "");
+    document.body.innerHTML = body;
+    globalThis.window = window;
+    globalThis.document = document;
+    globalThis.Blob = window.Blob;
+    globalThis.btoa = window.btoa;
+    Object.defineProperty(globalThis, "navigator", { value: window.navigator, configurable: true });
+    Object.defineProperty(globalThis, "localStorage", { value: window.localStorage, configurable: true });
+    localStorage.clear();
+    Object.defineProperty(navigator, "clipboard", { value: { writeText: vi.fn() }, configurable: true });
+    vi.resetModules();
+    ({ addNote, copyNotes } = await import(scriptURL));
+  });
+
+  it("adds transcribed note", () => {
+    addNote("hi");
+    const items = document.querySelectorAll("#notes-list li");
+    expect(items.length).toBe(1);
+    expect(items[0].textContent).toContain("hi");
+  });
+
+  it("copies markdown list", async () => {
+    addNote("hi");
+    await copyNotes();
+    expect(navigator.clipboard.writeText).toHaveBeenCalledWith("- hi");
+  });
+});


### PR DESCRIPTION
## Summary
- add Voice Notes tool to record audio, transcribe via Gemini 2.5 Flash, and manage notes in local storage
- allow copying notes as Markdown and deleting individual entries
- list Voice Notes in tools directory

## Testing
- `npm run lint`
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68c636cc4d50832ca77856f512de2cdc