### PR TITLE
Remove contenteditable attribute from recall card

### DIFF
--- a/recall/card.js
+++ b/recall/card.js
@@ -109,7 +109,7 @@ export async function createCard(parent, opts = {}) {
     index = i;
     const note = view[i];
     card.note = note;
-    ui.content.innerHTML = `<div class="form-control note-text" contenteditable>${marked.parse(note)}</div>`;
+    ui.content.innerHTML = `<div class="form-control note-text">${marked.parse(note)}</div>`;
     ui.indexInput.value = i + 1;
     ui.content.querySelector(".note-text").oninput = (e) => (card.note = e.target.innerText);
   }


### PR DESCRIPTION
## Summary
- remove the contenteditable attribute from the rendered note text container in the recall card

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68d8e67f632c832c825c1dd9b3445da4