### PR TITLE
Allow recall files to override decay rate

### DIFF
--- a/recall/card.js
+++ b/recall/card.js
@@ -2,6 +2,8 @@ import { marked } from "https://cdn.jsdelivr.net/npm/marked/+esm";
 import { bootstrapAlert } from "https://cdn.jsdelivr.net/npm/bootstrap-alert@1";
 import { files, fetchAll, filterNotes, renderStar } from "./notes.js";
 
+const DEFAULT_DECAY = 0.02;
+
 export async function createCard(parent, opts = {}) {
   const { deletable = false, exclude = () => [], showAllOnSearch = false } = opts;
   parent.insertAdjacentHTML(
@@ -74,6 +76,8 @@ export async function createCard(parent, opts = {}) {
   async function load() {
     ui.content.innerHTML = `<div class="text-center"><div class="spinner-border" role="status"></div></div>`;
     const url = ui.fileSel.value;
+    const file = files.find((f) => f.url === url);
+    ui.decayInput.value = file?.decay ?? DEFAULT_DECAY;
     items = await fetchAll(url ? [url] : files.filter((f) => f.preload).map((f) => f.url));
     ui.searchInput.value = "";
     index = 0;

--- a/recall/notes.js
+++ b/recall/notes.js
@@ -17,10 +17,12 @@ export const files = [
     url: "https://raw.githubusercontent.com/sanand0/til/refs/heads/live/core-concepts.md",
     name: "Core concepts",
     preload: true,
+    decay: 0,
   },
   {
     url: "https://raw.githubusercontent.com/sanand0/til/refs/heads/live/creative-ideas.md",
     name: "Creative ideas",
+    decay: 0,
   },
   {
     url: "https://raw.githubusercontent.com/sanand0/til/refs/heads/live/apps.md",
@@ -29,14 +31,17 @@ export const files = [
   {
     url: "https://raw.githubusercontent.com/sanand0/til/refs/heads/live/ai-capabilities.md",
     name: "AI Capabilities",
+    decay: 0,
   },
   {
     url: "https://raw.githubusercontent.com/sanand0/til/refs/heads/live/questions.md",
     name: "Questions to ask",
+    decay: 0,
   },
   {
     url: "https://notes.s-anand.net/transcripts.md",
     name: "🔒 Transcript notes",
+    decay: 0,
   },
   {
     url: "https://notes.s-anand.net/explore.md",
@@ -49,6 +54,7 @@ export const files = [
   {
     url: "https://raw.githubusercontent.com/sanand0/til/refs/heads/live/claude-code-uses.md",
     name: "Claude Code Uses",
+    decay: 0,
   },
 ];
 

--- a/recall/recall.test.js
+++ b/recall/recall.test.js
@@ -11,7 +11,7 @@ vi.mock("https://cdn.jsdelivr.net/npm/marked/+esm", () => ({ marked: { parse: (s
 vi.mock("./notes.js", () => ({
   files: [
     { url: "a", name: "A" },
-    { url: "b", name: "B" },
+    { url: "b", name: "B", decay: 0 },
   ],
   fetchAll: async () => ["- A", "- B"],
   filterNotes: (items) => items,
@@ -52,5 +52,18 @@ describe("recall card", () => {
     expect(card.star).toBe(true);
     expect(btn.className).toContain("btn-warning");
     expect(btn.innerHTML).toContain("bi-star-fill");
+  });
+
+  it("applies file-specific decay", async () => {
+    await import("./script.js");
+    const card = document.querySelector(".note-card");
+    const decay = card.querySelector(".note-decay");
+    expect(decay.value).toBe("0.02");
+    const sel = card.querySelector(".note-file");
+    sel.value = "b";
+    sel.dispatchEvent(new window.Event("change"));
+    await Promise.resolve();
+    await Promise.resolve();
+    expect(decay.value).toBe("0");
   });
 });


### PR DESCRIPTION
## Summary
- allow recall cards to reset the decay input based on the selected note file
- set zero decay for transcripts, core concepts, creative ideas, AI capabilities, questions, and Claude Code uses
- add a regression test covering the file-specific decay value

## Testing
- npm run lint
- npm test -- recall

------
https://chatgpt.com/codex/tasks/task_e_68e44f5db7b8832c8005898aad5c4d03